### PR TITLE
fix: dispose polyfill fallback logic

### DIFF
--- a/packages/tcpip/polyfills/disposable.ts
+++ b/packages/tcpip/polyfills/disposable.ts
@@ -1,20 +1,16 @@
 /**
- * Scoped polyfill for `Symbol.dispose` and `Symbol.asyncDispose` without
- * polluting the global scope. Required for the `using` keyword which we
- * use internally.
+ * Scoped polyfill for `Symbol.dispose` without polluting the global scope.
+ * Required for the `using` keyword which we use internally.
  * 
- * We export these symbols as 'Symbol.dispose' and 'Symbol.asyncDispose'
- * which tells ESBuild to inject them into the output bundle.
+ * We export this symbol as 'Symbol.dispose' which tells ESBuild to inject
+ * it into the output bundle.
  * 
  * The below works because Typescript's `using` implementation falls back to
- * `Symbol.for("Symbol.dispose")` and `Symbol.for("Symbol.asyncDispose")` if the
- * built-in `Symbol.dispose` and `Symbol.asyncDispose` are not available.
+ * `Symbol.for("Symbol.dispose")` if the built-in `Symbol.dispose` is not available.
  */
 
-const DisposeSymbol = Symbol.for('Symbol.dispose');
-const AsyncDisposeSymbol = Symbol.for('Symbol.asyncDispose');
+const DisposeSymbol = 'dispose' in (Symbol as object) ? Symbol.dispose : Symbol.for('Symbol.dispose');
 
 export {
-  DisposeSymbol as 'Symbol.dispose',
-  AsyncDisposeSymbol as 'Symbol.asyncDispose'
+  DisposeSymbol as 'Symbol.dispose'
 };


### PR DESCRIPTION
The recent `Symbol.dispose` [polyfill](https://github.com/chipmk/tcpip.js/pull/3) logic fixed environments that don't implement `Symbol.dispose` but broke environments that do. This fixes the fallback logic in the polyfill so that it works correctly in all environments.