### PR TITLE
Fix loopback interface not working for IPs other than 127.0.0.1

### DIFF
--- a/packages/tcpip/wasm/loopback_interface.c
+++ b/packages/tcpip/wasm/loopback_interface.c
@@ -39,6 +39,7 @@ loopback_interface *create_loopback_interface(const uint8_t *ip4, const uint8_t 
 
   netif_add(&interface->netif, &ipaddr, &netmask_addr, NULL, interface, netif_loopif_init, ip_input);
 
+  netif_set_link_up(&interface->netif);
   netif_set_up(&interface->netif);
 
   return interface;


### PR DESCRIPTION
lwIP has a special case for 127.0.0.1 that works regardless of whether or not an interface uses that IP. This fixes loopback interfaces to support any arbitrary IP.