### PR TITLE
DNS server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1012,6 +1012,10 @@
         "win32"
       ]
     },
+    "node_modules/@tcpip/dns": {
+      "resolved": "packages/dns",
+      "link": true
+    },
     "node_modules/@tcpip/v86": {
       "resolved": "packages/v86",
       "link": true
@@ -4397,6 +4401,302 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/dns": {
+      "name": "@tcpip/dns",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@total-typescript/tsconfig": "^1.0.4",
+        "tcpip": "0.2",
+        "typescript": "^5.0.4",
+        "vitest": "^3.0.1"
+      }
+    },
+    "packages/dns/node_modules/@vitest/browser": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-3.0.4.tgz",
+      "integrity": "sha512-CMUG+OYJvXoe5ylGzmAU3eVX6d848FvRc+1j/STOi3bHBIv4kfXgUrvPuxJVzl6kOad57Vg+SKBvNjeBoc4esw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@testing-library/dom": "^10.4.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@vitest/mocker": "3.0.4",
+        "@vitest/utils": "3.0.4",
+        "magic-string": "^0.30.17",
+        "msw": "^2.7.0",
+        "sirv": "^3.0.0",
+        "tinyrainbow": "^2.0.0",
+        "ws": "^8.18.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "vitest": "3.0.4",
+        "webdriverio": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": true
+        },
+        "safaridriver": {
+          "optional": true
+        },
+        "webdriverio": {
+          "optional": true
+        }
+      }
+    },
+    "packages/dns/node_modules/@vitest/expect": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.4.tgz",
+      "integrity": "sha512-Nm5kJmYw6P2BxhJPkO3eKKhGYKRsnqJqf+r0yOGRKpEP+bSCBDsjXgiu1/5QFrnPMEgzfC38ZEjvCFgaNBC0Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.0.4",
+        "@vitest/utils": "3.0.4",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/dns/node_modules/@vitest/mocker": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.4.tgz",
+      "integrity": "sha512-gEef35vKafJlfQbnyOXZ0Gcr9IBUsMTyTLXsEQwuyYAerpHqvXhzdBnDFuHLpFqth3F7b6BaFr4qV/Cs1ULx5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.0.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "packages/dns/node_modules/@vitest/pretty-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.4.tgz",
+      "integrity": "sha512-ts0fba+dEhK2aC9PFuZ9LTpULHpY/nd6jhAQ5IMU7Gaj7crPCTdCFfgvXxruRBLFS+MLraicCuFXxISEq8C93g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/dns/node_modules/@vitest/runner": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.4.tgz",
+      "integrity": "sha512-dKHzTQ7n9sExAcWH/0sh1elVgwc7OJ2lMOBrAm73J7AH6Pf9T12Zh3lNE1TETZaqrWFXtLlx3NVrLRb5hCK+iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.0.4",
+        "pathe": "^2.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/dns/node_modules/@vitest/snapshot": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.4.tgz",
+      "integrity": "sha512-+p5knMLwIk7lTQkM3NonZ9zBewzVp9EVkVpvNta0/PlFWpiqLaRcF4+33L1it3uRUCh0BGLOaXPPGEjNKfWb4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.0.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/dns/node_modules/@vitest/spy": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.4.tgz",
+      "integrity": "sha512-sXIMF0oauYyUy2hN49VFTYodzEAu744MmGcPR3ZBsPM20G+1/cSW/n1U+3Yu/zHxX2bIDe1oJASOkml+osTU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/dns/node_modules/@vitest/ui": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.0.4.tgz",
+      "integrity": "sha512-e+s2F9e9FUURkZ5aFIe1Fi3Y8M7UF6gEuShcaV/ur7y/Ldri+1tzWQ1TJq9Vas42NXnXvCAIrU39Z4U2RyET6g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vitest/utils": "3.0.4",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.2",
+        "pathe": "^2.0.2",
+        "sirv": "^3.0.0",
+        "tinyglobby": "^0.2.10",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "3.0.4"
+      }
+    },
+    "packages/dns/node_modules/@vitest/utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.4.tgz",
+      "integrity": "sha512-8BqC1ksYsHtbWH+DfpOAKrFw3jl3Uf9J7yeFh85Pz52IWuh1hBBtyfEbRNNZNjl8H8A5yMLH9/t+k7HIKzQcZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.0.4",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/dns/node_modules/pathe": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.2.tgz",
+      "integrity": "sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/dns/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/dns/node_modules/vite-node": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.4.tgz",
+      "integrity": "sha512-7JZKEzcYV2Nx3u6rlvN8qdo3QV7Fxyt6hx+CCKz9fbWxdX5IvUOmTWEAxMrWxaiSf7CKGLJQ5rFu8prb/jBjOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.0",
+        "es-module-lexer": "^1.6.0",
+        "pathe": "^2.0.2",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/dns/node_modules/vitest": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.4.tgz",
+      "integrity": "sha512-6XG8oTKy2gnJIFTHP6LD7ExFeNLxiTkK3CfMvT7IfR8IN+BYICCf0lXUQmX7i7JoxUP8QmeP4mTnWXgflu4yjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "3.0.4",
+        "@vitest/mocker": "3.0.4",
+        "@vitest/pretty-format": "^3.0.4",
+        "@vitest/runner": "3.0.4",
+        "@vitest/snapshot": "3.0.4",
+        "@vitest/spy": "3.0.4",
+        "@vitest/utils": "3.0.4",
+        "chai": "^5.1.2",
+        "debug": "^4.4.0",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinypool": "^1.0.2",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0",
+        "vite-node": "3.0.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.0.4",
+        "@vitest/ui": "3.0.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "packages/tcpip": {

--- a/packages/dns/package.json
+++ b/packages/dns/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@tcpip/dns",
+  "version": "0.1.0",
+  "description": "DNS server built on tcpip.js",
+  "main": "dist/index.cjs",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "build": "tsup --clean",
+    "test": "vitest",
+    "prepublishOnly": "npm run build"
+  },
+  "files": [
+    "dist/**/*"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.cjs"
+    }
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@total-typescript/tsconfig": "^1.0.4",
+    "tcpip": "0.2",
+    "typescript": "^5.0.4",
+    "vitest": "^3.0.1"
+  }
+}

--- a/packages/dns/src/constants.ts
+++ b/packages/dns/src/constants.ts
@@ -1,0 +1,26 @@
+export const TypeCode = {
+  A: 1, // IPv4
+  NS: 2, // Nameserver
+  CNAME: 5, // Canonical name
+  SOA: 6, // Start of authority
+  PTR: 12, // Pointer
+  MX: 15, // Mail exchange
+  TXT: 16, // Text
+  AAAA: 28, // IPv6
+  SRV: 33, // Service locator
+  ANY: 255, // Any
+} as const;
+
+export const ClassCode = {
+  IN: 1, // Internet
+} as const;
+
+export const OpCode = {
+  QUERY: 0, // Standard query
+} as const;
+
+export const RCode = {
+  NOERROR: 0, // No error
+  SERVFAIL: 2, // Server failure
+  NXDOMAIN: 3, // Non-existent domain
+} as const;

--- a/packages/dns/src/dns-server.ts
+++ b/packages/dns/src/dns-server.ts
@@ -1,0 +1,158 @@
+import type { NetworkStack, UdpDatagram, UdpSocket } from 'tcpip';
+import type { DnsMessage, DnsRecord, DnsResponse, DnsType } from './types.js';
+import { parseDnsMessage, serializeDnsMessage } from './wire.js';
+
+export type RequestFn = (query: {
+  name: string;
+  type: DnsType;
+}) => Promise<DnsResponse | DnsResponse[] | void>;
+
+export type DnsServerOptions = {
+  /**
+   * Port to listen on.
+   *
+   * @default 53
+   */
+  port?: number;
+
+  /**
+   * `tcpip` network stack to use.
+   */
+  stack: NetworkStack;
+
+  /**
+   * Callback function to handle DNS queries.
+   */
+  request: RequestFn;
+};
+
+export async function createDnsServer(options: DnsServerOptions) {
+  const server = new DnsServer(options);
+  await server.listen();
+  return server;
+}
+
+export class DnsServer {
+  #options: DnsServerOptions;
+
+  constructor(options: DnsServerOptions) {
+    this.#options = options;
+  }
+
+  async listen() {
+    const socket = await this.#options.stack.openUdp({
+      port: this.#options.port ?? 53,
+    });
+    this.#processDnsMessages(socket);
+  }
+
+  async #processDnsMessages(socket: UdpSocket) {
+    const writer = socket.writable.getWriter();
+
+    for await (const datagram of socket) {
+      // Process each message without blocking
+      this.#processDnsMessage(datagram, writer);
+    }
+  }
+
+  async #processDnsMessage(
+    datagram: UdpDatagram,
+    writer: WritableStreamDefaultWriter<UdpDatagram>
+  ) {
+    try {
+      const { host, port } = datagram;
+      const requestMessage = parseDnsMessage(datagram.data);
+      const responseMessage = await handleRequestMessage(
+        requestMessage,
+        this.#options.request
+      );
+      const data = serializeDnsMessage(responseMessage);
+      await writer.write({ host, port, data });
+    } catch (err) {
+      console.error('error handling dns query:', err);
+    }
+  }
+}
+
+async function handleRequestMessage(
+  requestMessage: DnsMessage,
+  request: RequestFn
+) {
+  if (requestMessage.questions.length > 1) {
+    throw new Error('only one dns question is supported');
+  }
+
+  const [question] = requestMessage.questions;
+
+  if (!question) {
+    throw new Error('no question found in dns message');
+  }
+
+  if (question.class !== 'IN') {
+    throw new Error('only IN class is supported');
+  }
+
+  // Get response from user's handler
+  const response = await request({
+    name: question.name,
+    type: question.type,
+  });
+
+  // Convert back to DNS message format
+  return createResponseMessage(requestMessage, response);
+}
+
+/**
+ * Convert a response from the user's handler to a DNS message.
+ */
+function createResponseMessage(
+  query: DnsMessage,
+  response: DnsResponse | DnsResponse[] | void
+): DnsMessage {
+  // Handle undefined response (NXDOMAIN)
+  if (!response) {
+    return {
+      header: {
+        ...query.header,
+        isResponse: true,
+        isRecursionAvailable: false,
+        rcode: 'NXDOMAIN',
+      },
+      questions: query.questions,
+      answers: [],
+      authorities: [],
+      additionals: [],
+    };
+  }
+
+  const question = query.questions[0];
+
+  if (!question) {
+    throw new Error('no question found in dns message');
+  }
+
+  if (question.class !== 'IN') {
+    throw new Error('only IN class is supported');
+  }
+
+  const responses = Array.isArray(response) ? response : [response];
+
+  const answers = responses.map<DnsRecord>((response) => ({
+    name: question.name,
+    class: 'IN',
+    ...response,
+  }));
+
+  return {
+    header: {
+      ...query.header,
+      isResponse: true,
+      isRecursionAvailable: false,
+      rcode: 'NOERROR',
+    },
+    questions: query.questions,
+    answers,
+    authorities: [],
+    additionals: [],
+  };
+}

--- a/packages/dns/src/index.ts
+++ b/packages/dns/src/index.ts
@@ -1,0 +1,3 @@
+export * from './dns-server.js';
+export type { DnsResponse, DnsType } from './types.js';
+export { ptrNameToIP } from './util.js';

--- a/packages/dns/src/types.ts
+++ b/packages/dns/src/types.ts
@@ -1,0 +1,102 @@
+import type { ClassCode, TypeCode, OpCode, RCode } from './constants.js';
+
+export type DnsType = keyof typeof TypeCode;
+export type DnsClass = keyof typeof ClassCode;
+export type DnsOpCode = keyof typeof OpCode;
+export type DnsRCode = keyof typeof RCode;
+
+export type DnsHeader = {
+  id: number;
+  isResponse: boolean;
+  opcode: DnsOpCode;
+  isAuthoritativeAnswer: boolean;
+  isTruncated: boolean;
+  isRecursionDesired: boolean;
+  isRecursionAvailable: boolean;
+  rcode: DnsRCode;
+  questionCount: number;
+  answerCount: number;
+  authorityCount: number;
+  additionalCount: number;
+};
+
+export type DnsQuestion = {
+  name: string;
+  type: DnsType;
+  class: DnsClass;
+};
+
+export type DnsBaseRecord = {
+  name: string;
+  class: DnsClass;
+  ttl: number;
+};
+
+export type DnsARecord = DnsBaseRecord & {
+  type: 'A';
+  ip: string;
+};
+
+export type DnsAAAARecord = DnsBaseRecord & {
+  type: 'AAAA';
+  ip: string;
+};
+
+export type DnsTxtRecord = DnsBaseRecord & {
+  type: 'TXT';
+  value: string;
+};
+
+export type DnsPtrRecord = DnsBaseRecord & {
+  type: 'PTR';
+  ptr: string;
+};
+
+export type DnsRecord =
+  | DnsARecord
+  | DnsAAAARecord
+  | DnsTxtRecord
+  | DnsPtrRecord;
+
+export type DnsBaseResponse = {
+  ttl: number;
+};
+
+export type DnsAResponse = DnsBaseResponse & {
+  type: 'A';
+  ip: string;
+};
+
+export type DnsAAAAResponse = DnsBaseResponse & {
+  type: 'AAAA';
+  ip: string;
+};
+
+export type DnsTxtResponse = DnsBaseResponse & {
+  type: 'TXT';
+  value: string;
+};
+
+export type DnsPtrResponse = DnsBaseResponse & {
+  type: 'PTR';
+  ptr: string;
+};
+
+export type DnsResponse =
+  | DnsAResponse
+  | DnsAAAAResponse
+  | DnsTxtResponse
+  | DnsPtrResponse;
+
+export type DnsQuery = {
+  name: string;
+  type: DnsType;
+};
+
+export type DnsMessage = {
+  header: DnsHeader;
+  questions: DnsQuestion[];
+  answers: DnsRecord[];
+  authorities: DnsRecord[];
+  additionals: DnsRecord[];
+};

--- a/packages/dns/src/util.test.ts
+++ b/packages/dns/src/util.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'vitest';
+import { compressIPv6, expandIPv6, ptrNameToIP } from './util';
+
+describe('ptrNameToIP', () => {
+  test('should convert PTR name to an IPv4 address', () => {
+    const result = ptrNameToIP('1.0.0.10.in-addr.arpa');
+    expect(result.type).toBe('ipv4');
+    expect(result.ip).toBe('10.0.0.1');
+  });
+
+  test('should convert PTR name to an IPv6 address', () => {
+    const result = ptrNameToIP(
+      'b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa'
+    );
+    expect(result.type).toBe('ipv6');
+    expect(result.ip).toBe('2001:db8::567:89ab');
+  });
+
+  test('should throw an error for invalid top level domain', () => {
+    expect(() => ptrNameToIP('1.0.0.10.in-addr.com')).toThrow(
+      'invalid PTR name: 1.0.0.10.in-addr.com'
+    );
+  });
+
+  test('should throw an error for invalid second level domain', () => {
+    expect(() => ptrNameToIP('1.0.0.10.invalid.arpa')).toThrow(
+      'invalid PTR name: 1.0.0.10.invalid.arpa'
+    );
+  });
+
+  test('should handle empty input', () => {
+    expect(() => ptrNameToIP('')).toThrow('invalid PTR name: ');
+  });
+});
+
+describe('compressIPv6', () => {
+  test('compresses an IPv6 address with leading zeros', () => {
+    const ip = '0000:0000:0000:0000:0000:0000:0000:0001';
+    const compressed = compressIPv6(ip);
+    expect(compressed).toBe('::1');
+  });
+
+  test('compresses an IPv6 address with trailing zeros', () => {
+    const ip = '2001:0000:0000:0000:0000:0000:0000:0000';
+    const compressed = compressIPv6(ip);
+    expect(compressed).toBe('2001::');
+  });
+
+  test('compresses an IPv6 address with consecutive zeros', () => {
+    const ip = '2001:0db8:0000:0000:0000:0000:0000:0001';
+    const compressed = compressIPv6(ip);
+    expect(compressed).toBe('2001:db8::1');
+  });
+
+  test('compresses an IPv6 address with no zeros', () => {
+    const ip = '2001:db8:1234:5678:9abc:def0:1234:5678';
+    const compressed = compressIPv6(ip);
+    expect(compressed).toBe('2001:db8:1234:5678:9abc:def0:1234:5678');
+  });
+
+  test('compresses an IPv6 address with a single zero block', () => {
+    const ip = '2001:db8:0:1:0:0:0:1';
+    const compressed = compressIPv6(ip);
+    expect(compressed).toBe('2001:db8:0:1::1');
+  });
+
+  test('compresses an IPv6 address with multiple zero blocks', () => {
+    const ip = '2001:0:0:1:0:0:0:1';
+    const compressed = compressIPv6(ip);
+    expect(compressed).toBe('2001:0:0:1::1');
+  });
+});
+
+describe('expandIPv6', () => {
+  test('expands an IPv6 address with leading zeros', () => {
+    const ip = '::1';
+    const expanded = expandIPv6(ip);
+    expect(expanded).toBe('0000:0000:0000:0000:0000:0000:0000:0001');
+  });
+
+  test('expands an IPv6 address with trailing zeros', () => {
+    const ip = '2001::';
+    const expanded = expandIPv6(ip);
+    expect(expanded).toBe('2001:0000:0000:0000:0000:0000:0000:0000');
+  });
+
+  test('expands an IPv6 address with consecutive zeros', () => {
+    const ip = '2001:db8::1';
+    const expanded = expandIPv6(ip);
+    expect(expanded).toBe('2001:0db8:0000:0000:0000:0000:0000:0001');
+  });
+
+  test('expands an IPv6 address with partial zeros', () => {
+    const ip = '2001:db8:1234:5678:9abc:def0:1234:5678';
+    const expanded = expandIPv6(ip);
+    expect(expanded).toBe('2001:0db8:1234:5678:9abc:def0:1234:5678');
+  });
+
+  test('expands an IPv6 address with a single zero block', () => {
+    const ip = '2001:db8:0:1::1';
+    const expanded = expandIPv6(ip);
+    expect(expanded).toBe('2001:0db8:0000:0001:0000:0000:0000:0001');
+  });
+
+  test('expands an IPv6 address with multiple zero blocks', () => {
+    const ip = '2001:0:0:1::1';
+    const expanded = expandIPv6(ip);
+    expect(expanded).toBe('2001:0000:0000:0001:0000:0000:0000:0001');
+  });
+});

--- a/packages/dns/src/util.ts
+++ b/packages/dns/src/util.ts
@@ -1,0 +1,164 @@
+/**
+ * Chunk a string into parts of a given size.
+ */
+export function chunk(value: string, size: number) {
+  const parts = [];
+  for (let i = 0; i < value.length; i += size) {
+    parts.push(value.slice(i, i + size));
+  }
+  return parts;
+}
+
+export type PtrIPv4 = {
+  type: 'ipv4';
+  ip: string;
+};
+
+export type PtrIPv6 = {
+  type: 'ipv6';
+  ip: string;
+};
+
+export type PtrIP = PtrIPv4 | PtrIPv6;
+
+/**
+ * Converts a reversed PTR name to an IPv4 or IPv6 address.
+ *
+ * @example
+ * // Convert PTR name to an IPv4 address
+ * ptrNameToIP('1.0.0.10.in-addr.arpa');
+ * // { type: 'ipv4', ip: '10.0.0.1' }
+ *
+ * @example
+ * // Convert PTR name to an IPv6 address
+ * ptrNameToIP(
+ *  'b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa'
+ * );
+ * // { type: 'ipv6', ip: '2001:db8::567:89ab' }
+ */
+export function ptrNameToIP(name: string): PtrIP {
+  const [first, second, ...parts] = name
+    .split('.')
+    .reverse()
+    .filter((part) => !!part);
+
+  // Top level domain must be 'arpa'
+  if (first !== 'arpa') {
+    throw new Error(`invalid PTR name: ${name}`);
+  }
+
+  // Second level domain must be 'in-addr' or 'ip6'
+  switch (second) {
+    case 'in-addr':
+      return {
+        type: 'ipv4',
+        ip: parts.join('.'),
+      };
+
+    case 'ip6':
+      return {
+        type: 'ipv6',
+        ip: compressIPv6(
+          parts
+            .join('')
+            .replace(/(.{4})/g, '$1:')
+            .replace(/:$/, '')
+        ),
+      };
+
+    default:
+      throw new Error(`invalid PTR name: ${name}`);
+  }
+}
+
+/**
+ * Compresses an IPv6 address by removing leading zeros.
+ */
+export function compressIPv6(ip: string) {
+  // Split into groups and normalize to lowercase
+  const groups = ip.toLowerCase().split(':');
+
+  // Remove leading zeros from each group
+  const normalizedGroups = groups.map(
+    (group) => group.replace(/^0+(?=\w)/, '') // Remove leading zeros, keep single 0
+  );
+
+  // Find longest sequence of empty groups
+  let longestZeroStart = -1;
+  let longestZeroLength = 0;
+  let currentZeroStart = -1;
+  let currentZeroLength = 0;
+
+  for (let i = 0; i < normalizedGroups.length; i++) {
+    if (normalizedGroups[i] === '0' || normalizedGroups[i] === '') {
+      if (currentZeroStart === -1) currentZeroStart = i;
+      currentZeroLength++;
+
+      if (currentZeroLength > longestZeroLength) {
+        longestZeroStart = currentZeroStart;
+        longestZeroLength = currentZeroLength;
+      }
+    } else {
+      currentZeroStart = -1;
+      currentZeroLength = 0;
+    }
+  }
+
+  // Replace longest zero sequence with :: if it's at least 2 groups long
+  if (longestZeroLength >= 2) {
+    // Clear out the zero sequence
+    normalizedGroups.splice(longestZeroStart, longestZeroLength);
+
+    // Insert empty string for :: compression
+    if (longestZeroStart === 0) {
+      // Leading zeros - ensure we have two colons at start
+      normalizedGroups.unshift('', '');
+    } else if (longestZeroStart === normalizedGroups.length) {
+      // Trailing zeros - ensure we have two colons at end
+      normalizedGroups.push('', '');
+    } else {
+      // Middle zeros - add empty string for ::
+      normalizedGroups.splice(longestZeroStart, 0, '');
+    }
+  }
+
+  return normalizedGroups.join(':');
+}
+
+/**
+ * Expands an IPv6 address by adding leading zeros.
+ */
+export function expandIPv6(ip: string) {
+  // Handle empty string edge case
+  if (!ip) {
+    throw new Error(`invalid IPv6 address: ${ip}`);
+  }
+
+  // Split on :: to handle compressed zeros
+  const doubleColonSplit = ip.split('::').map((part) => part.split(':'));
+
+  if (doubleColonSplit.length > 2) {
+    throw new Error(`invalid IPv6 address: ${ip}`);
+  }
+
+  const [left, right] = doubleColonSplit;
+
+  if (!left) {
+    throw new Error(`invalid IPv6 address: ${ip}`);
+  }
+
+  // If no :: compression, just pad each group
+  if (!right) {
+    return left.map((group) => group.padStart(4, '0')).join(':');
+  }
+
+  // Calculate how many zero groups we need
+  const totalGroups = 8;
+  const missingGroups = totalGroups - (left.length + right.length);
+  const zeros = Array(missingGroups).fill('0000');
+
+  // Combine all parts and pad each group
+  return [...left, ...zeros, ...right]
+    .map((group) => group.padStart(4, '0'))
+    .join(':');
+}

--- a/packages/dns/src/wire.ts
+++ b/packages/dns/src/wire.ts
@@ -1,0 +1,314 @@
+import { ClassCode, OpCode, RCode, TypeCode } from './constants.js';
+import type {
+  DnsClass,
+  DnsHeader,
+  DnsMessage,
+  DnsOpCode,
+  DnsQuestion,
+  DnsRCode,
+  DnsRecord,
+  DnsType,
+} from './types.js';
+import { chunk } from './util.js';
+
+export function parseName(
+  data: Uint8Array,
+  offset: number
+): [name: string, offset: number] {
+  const parts: string[] = [];
+  let currentOffset = offset;
+
+  while (true) {
+    const length = data[currentOffset];
+    if (length === undefined || length === 0) {
+      break;
+    }
+
+    currentOffset++;
+    const part = new TextDecoder().decode(
+      data.slice(currentOffset, currentOffset + length)
+    );
+    parts.push(part);
+    currentOffset += length;
+  }
+
+  return [parts.join('.'), currentOffset + 1];
+}
+
+export function serializeName(name: string): Uint8Array {
+  const parts = name.split('.');
+  const bytes = new Uint8Array(name.length + 2); // +2 for length bytes
+  let offset = 0;
+
+  for (const part of parts) {
+    bytes[offset] = part.length;
+    offset++;
+    for (let i = 0; i < part.length; i++) {
+      bytes[offset + i] = part.charCodeAt(i);
+    }
+    offset += part.length;
+  }
+
+  bytes[offset] = 0; // Root label
+  return bytes.slice(0, offset + 1);
+}
+
+export function parseDnsType(type: number) {
+  const [key] =
+    Object.entries(TypeCode).find(([, value]) => value === type) ?? [];
+  return key as DnsType;
+}
+
+export function serializeDnsType(type: DnsType) {
+  return TypeCode[type];
+}
+
+export function parseDnsClass(cls: number) {
+  const [key] =
+    Object.entries(ClassCode).find(([, value]) => value === cls) ?? [];
+  return key as DnsClass;
+}
+
+export function serializeDnsClass(cls: DnsClass) {
+  return ClassCode[cls];
+}
+
+export function parseDnsOpCode(opcode: number) {
+  const [key] =
+    Object.entries(OpCode).find(([, value]) => value === opcode) ?? [];
+  return key as DnsOpCode;
+}
+
+export function serializeDnsOpCode(opcode: DnsOpCode) {
+  return OpCode[opcode];
+}
+
+export function parseDnsRCode(rcode: number) {
+  const [key] =
+    Object.entries(RCode).find(([, value]) => value === rcode) ?? [];
+  return key as DnsRCode;
+}
+
+export function serializeDnsRCode(rcode: DnsRCode) {
+  return RCode[rcode];
+}
+
+export function serializeQuestion(q: DnsQuestion) {
+  const nameBytes = serializeName(q.name);
+  const buffer = new Uint8Array(nameBytes.length + 4);
+  const view = new DataView(buffer.buffer);
+  let offset = 0;
+
+  buffer.set(nameBytes, offset);
+  offset += nameBytes.length;
+
+  view.setUint16(offset, serializeDnsType(q.type));
+  view.setUint16(offset + 2, serializeDnsClass(q.class));
+  return buffer;
+}
+
+/**
+ * Serialize a TXT record value.
+ */
+export function serializeTxtValue(value: string) {
+  const encoder = new TextEncoder();
+
+  // TXT records are split into chunks of 255 bytes
+  const parts = chunk(value, 255);
+
+  // Each part needs a length byte followed by the text
+  const buffer = new Uint8Array(parts.length * (1 + 255));
+
+  let offset = 0;
+
+  for (const part of parts) {
+    buffer[offset] = part.length;
+    buffer.set(encoder.encode(part), offset + 1);
+    offset += 1 + 255;
+  }
+
+  return buffer;
+}
+
+export function serializeResourceData(record: DnsRecord) {
+  switch (record.type) {
+    case 'A':
+      return serializeIPv4Address(record.ip);
+    case 'AAAA':
+      return serializeIPv6Address(record.ip);
+    case 'TXT':
+      return serializeTxtValue(record.value);
+    case 'PTR':
+      return serializeName(record.ptr);
+    default:
+      throw new Error('unsupported record type');
+  }
+}
+
+export function serializeAnswer(record: DnsRecord) {
+  const HEADER_LENGTH = 10;
+
+  const nameBytes = serializeName(record.name);
+  const resourceData = serializeResourceData(record);
+
+  const buffer = new Uint8Array(
+    nameBytes.length + HEADER_LENGTH + resourceData.length
+  );
+  const view = new DataView(buffer.buffer);
+  let offset = 0;
+
+  buffer.set(nameBytes, offset);
+  offset += nameBytes.length;
+
+  // Write the 10 byte header
+  view.setUint16(offset, serializeDnsType(record.type));
+  view.setUint16(offset + 2, serializeDnsClass(record.class));
+  view.setUint32(offset + 4, record.ttl);
+  view.setUint16(offset + 8, resourceData.length);
+
+  // Increment offset over the header
+  offset += HEADER_LENGTH;
+
+  // Write the resource data
+  buffer.set(resourceData, offset);
+
+  return buffer;
+}
+
+export function parseDnsMessage(data: Uint8Array): DnsMessage {
+  if (data.length < 12) {
+    throw new Error('DNS message is too short');
+  }
+
+  let offset = 0;
+
+  // Parse header
+  const view = new DataView(data.buffer);
+  const header: DnsHeader = {
+    id: view.getUint16(0),
+    isResponse: Boolean(data[2]! & 0x80),
+    opcode: parseDnsOpCode((data[2]! >> 3) & 0x0f),
+    isAuthoritativeAnswer: Boolean(data[2]! & 0x04),
+    isTruncated: Boolean(data[2]! & 0x02),
+    isRecursionDesired: Boolean(data[2]! & 0x01),
+    isRecursionAvailable: Boolean(data[3]! & 0x80),
+    rcode: parseDnsRCode(data[3]! & 0x0f),
+    questionCount: view.getUint16(4),
+    answerCount: view.getUint16(6),
+    authorityCount: view.getUint16(8),
+    additionalCount: view.getUint16(10),
+  };
+  offset = 12;
+
+  // Parse questions
+  const questions: DnsQuestion[] = [];
+  for (let i = 0; i < header.questionCount; i++) {
+    const [name, newOffset] = parseName(data, offset);
+    offset = newOffset;
+
+    const type = parseDnsType(view.getUint16(offset));
+    const cls = parseDnsClass(view.getUint16(offset + 2));
+    offset += 4;
+
+    questions.push({ name, type, class: cls });
+  }
+
+  return {
+    header,
+    questions,
+    answers: [],
+    authorities: [],
+    additionals: [],
+  };
+}
+
+export function serializeDnsMessage(message: DnsMessage): Uint8Array {
+  const HEADER_LENGTH = 12;
+
+  const questions = message.questions.map(serializeQuestion);
+  const answers = message.answers.map(serializeAnswer);
+
+  let size = HEADER_LENGTH;
+
+  // Add space for questions
+  for (const question of questions) {
+    size += question.length;
+  }
+
+  // Add space for answers
+  for (const answer of answers) {
+    size += answer.length;
+  }
+
+  const buffer = new Uint8Array(size);
+  const view = new DataView(buffer.buffer);
+  let offset = 0;
+
+  // Write header
+  view.setUint16(0, message.header.id);
+  buffer[2] =
+    (message.header.isResponse ? 0x80 : 0) |
+    ((serializeDnsOpCode(message.header.opcode) & 0x0f) << 3) |
+    (message.header.isAuthoritativeAnswer ? 0x04 : 0) |
+    (message.header.isTruncated ? 0x02 : 0) |
+    (message.header.isRecursionDesired ? 0x01 : 0);
+  buffer[3] =
+    (message.header.isRecursionAvailable ? 0x80 : 0) |
+    (serializeDnsRCode(message.header.rcode) & 0x0f);
+  view.setUint16(4, message.questions.length);
+  view.setUint16(6, message.answers.length);
+  view.setUint16(8, message.authorities.length);
+  view.setUint16(10, message.additionals.length);
+
+  offset = HEADER_LENGTH;
+
+  // Write questions
+  for (const question of questions) {
+    buffer.set(question, offset);
+    offset += question.length;
+  }
+
+  // Write answers
+  for (const answer of answers) {
+    buffer.set(answer, offset);
+    offset += answer.length;
+  }
+
+  return buffer;
+}
+
+/**
+ * Parses an IPv4 address Uint8Array into a string.
+ */
+export function parseIPv4Address(data: Uint8Array) {
+  return data.join('.');
+}
+
+/**
+ * Serialize an IPv4 address string into a Uint8Array.
+ */
+export function serializeIPv4Address(ip: string) {
+  return new Uint8Array(ip.split('.').map((byte) => parseInt(byte, 10)));
+}
+
+/**
+ * Parses an IPv6 address Uint8Array into a string.
+ */
+export function parseIPv6Address(data: Uint8Array) {
+  return data
+    .reduce((acc, byte) => acc + byte.toString(16).padStart(2, '0'), '')
+    .match(/.{1,4}/g)!
+    .join(':');
+}
+
+/**
+ * Serialize an IPv6 address string into a Uint8Array.
+ */
+export function serializeIPv6Address(ip: string) {
+  return new Uint8Array(
+    ip.split(':').flatMap((n) => {
+      const num = parseInt(n, 16);
+      return [num >> 8, num & 0xff];
+    })
+  );
+}

--- a/packages/dns/tsconfig.json
+++ b/packages/dns/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@total-typescript/tsconfig/bundler/dom/library",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/dns/tsup.config.ts
+++ b/packages/dns/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    outDir: 'dist',
+    sourcemap: true,
+    dts: true,
+    minify: true,
+    splitting: true,
+  },
+]);

--- a/packages/dns/vitest.config.ts
+++ b/packages/dns/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.{test,spec}.ts'],
+  },
+});


### PR DESCRIPTION
Adds basic DNS server. No built-in recursive querying or zone record handling - rather you implement a `request()` callback that can be used to resolve DNS queries as you wish.

```ts
import { createStack } from 'tcpip';
import { createDnsServer, ptrNameToIP } from '@tcpip/dns';

const stack = await createStack();

const tapInterface = await stack.createTapInterface({
  ip: '10.0.0.1/24',
  mac: '02:00:00:00:00:01',
});

const dnsServer = await createDnsServer({
  stack,
  async request(query) {
    const { type, name } = query;

    // Handle A record for example.com
    if (type === 'A' && name === 'example.com') {
      return {
        type,
        ip: '10.0.0.1',
        ttl: 300,
      };
    }

    // Handle reverse lookup for 10.0.0.1
    if (type === 'PTR') {
      const { type: ipType, ip } = ptrNameToIP(name);

      if (ipType === 'ipv4' && ip === '10.0.0.1') {
        return {
          type,
          ptr: 'example.com',
          ttl: 300,
        };
      }
    }
  },
});
```