### PR TITLE
DHCP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1012,6 +1012,10 @@
         "win32"
       ]
     },
+    "node_modules/@tcpip/dhcp": {
+      "resolved": "packages/dhcp",
+      "link": true
+    },
     "node_modules/@tcpip/v86": {
       "resolved": "packages/v86",
       "link": true
@@ -4397,6 +4401,302 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/dhcp": {
+      "name": "@tcpip/dhcp",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@total-typescript/tsconfig": "^1.0.4",
+        "tcpip": "0.2",
+        "typescript": "^5.0.4",
+        "vitest": "^3.0.1"
+      }
+    },
+    "packages/dhcp/node_modules/@vitest/browser": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-3.0.4.tgz",
+      "integrity": "sha512-CMUG+OYJvXoe5ylGzmAU3eVX6d848FvRc+1j/STOi3bHBIv4kfXgUrvPuxJVzl6kOad57Vg+SKBvNjeBoc4esw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@testing-library/dom": "^10.4.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@vitest/mocker": "3.0.4",
+        "@vitest/utils": "3.0.4",
+        "magic-string": "^0.30.17",
+        "msw": "^2.7.0",
+        "sirv": "^3.0.0",
+        "tinyrainbow": "^2.0.0",
+        "ws": "^8.18.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "vitest": "3.0.4",
+        "webdriverio": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": true
+        },
+        "safaridriver": {
+          "optional": true
+        },
+        "webdriverio": {
+          "optional": true
+        }
+      }
+    },
+    "packages/dhcp/node_modules/@vitest/expect": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.4.tgz",
+      "integrity": "sha512-Nm5kJmYw6P2BxhJPkO3eKKhGYKRsnqJqf+r0yOGRKpEP+bSCBDsjXgiu1/5QFrnPMEgzfC38ZEjvCFgaNBC0Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.0.4",
+        "@vitest/utils": "3.0.4",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/dhcp/node_modules/@vitest/mocker": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.4.tgz",
+      "integrity": "sha512-gEef35vKafJlfQbnyOXZ0Gcr9IBUsMTyTLXsEQwuyYAerpHqvXhzdBnDFuHLpFqth3F7b6BaFr4qV/Cs1ULx5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.0.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "packages/dhcp/node_modules/@vitest/pretty-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.4.tgz",
+      "integrity": "sha512-ts0fba+dEhK2aC9PFuZ9LTpULHpY/nd6jhAQ5IMU7Gaj7crPCTdCFfgvXxruRBLFS+MLraicCuFXxISEq8C93g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/dhcp/node_modules/@vitest/runner": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.4.tgz",
+      "integrity": "sha512-dKHzTQ7n9sExAcWH/0sh1elVgwc7OJ2lMOBrAm73J7AH6Pf9T12Zh3lNE1TETZaqrWFXtLlx3NVrLRb5hCK+iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.0.4",
+        "pathe": "^2.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/dhcp/node_modules/@vitest/snapshot": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.4.tgz",
+      "integrity": "sha512-+p5knMLwIk7lTQkM3NonZ9zBewzVp9EVkVpvNta0/PlFWpiqLaRcF4+33L1it3uRUCh0BGLOaXPPGEjNKfWb4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.0.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/dhcp/node_modules/@vitest/spy": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.4.tgz",
+      "integrity": "sha512-sXIMF0oauYyUy2hN49VFTYodzEAu744MmGcPR3ZBsPM20G+1/cSW/n1U+3Yu/zHxX2bIDe1oJASOkml+osTU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/dhcp/node_modules/@vitest/ui": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.0.4.tgz",
+      "integrity": "sha512-e+s2F9e9FUURkZ5aFIe1Fi3Y8M7UF6gEuShcaV/ur7y/Ldri+1tzWQ1TJq9Vas42NXnXvCAIrU39Z4U2RyET6g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vitest/utils": "3.0.4",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.2",
+        "pathe": "^2.0.2",
+        "sirv": "^3.0.0",
+        "tinyglobby": "^0.2.10",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "3.0.4"
+      }
+    },
+    "packages/dhcp/node_modules/@vitest/utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.4.tgz",
+      "integrity": "sha512-8BqC1ksYsHtbWH+DfpOAKrFw3jl3Uf9J7yeFh85Pz52IWuh1hBBtyfEbRNNZNjl8H8A5yMLH9/t+k7HIKzQcZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.0.4",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/dhcp/node_modules/pathe": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.2.tgz",
+      "integrity": "sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/dhcp/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/dhcp/node_modules/vite-node": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.4.tgz",
+      "integrity": "sha512-7JZKEzcYV2Nx3u6rlvN8qdo3QV7Fxyt6hx+CCKz9fbWxdX5IvUOmTWEAxMrWxaiSf7CKGLJQ5rFu8prb/jBjOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.0",
+        "es-module-lexer": "^1.6.0",
+        "pathe": "^2.0.2",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/dhcp/node_modules/vitest": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.4.tgz",
+      "integrity": "sha512-6XG8oTKy2gnJIFTHP6LD7ExFeNLxiTkK3CfMvT7IfR8IN+BYICCf0lXUQmX7i7JoxUP8QmeP4mTnWXgflu4yjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "3.0.4",
+        "@vitest/mocker": "3.0.4",
+        "@vitest/pretty-format": "^3.0.4",
+        "@vitest/runner": "3.0.4",
+        "@vitest/snapshot": "3.0.4",
+        "@vitest/spy": "3.0.4",
+        "@vitest/utils": "3.0.4",
+        "chai": "^5.1.2",
+        "debug": "^4.4.0",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinypool": "^1.0.2",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0",
+        "vite-node": "3.0.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.0.4",
+        "@vitest/ui": "3.0.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "packages/tcpip": {

--- a/packages/dhcp/package.json
+++ b/packages/dhcp/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@tcpip/dhcp",
+  "version": "0.1.0",
+  "description": "DHCP server built on tcpip.js",
+  "main": "dist/index.cjs",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "build": "tsup --clean",
+    "test": "vitest",
+    "prepublishOnly": "npm run build"
+  },
+  "files": [
+    "dist/**/*"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.cjs"
+    }
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@total-typescript/tsconfig": "^1.0.4",
+    "tcpip": "0.2",
+    "typescript": "^5.0.4",
+    "vitest": "^3.0.1"
+  }
+}

--- a/packages/dhcp/src/constants.ts
+++ b/packages/dhcp/src/constants.ts
@@ -1,0 +1,31 @@
+export const DHCP_SERVER_PORT = 67;
+export const DHCP_CLIENT_PORT = 68;
+
+// DHCP message types as per RFC 2132
+export const DHCPMessageTypes = {
+  DISCOVER: 1,
+  OFFER: 2,
+  REQUEST: 3,
+  DECLINE: 4,
+  ACK: 5,
+  NAK: 6,
+  RELEASE: 7,
+  INFORM: 8,
+} as const;
+
+// DHCP options codes as per RFC 2132
+export const DHCPOptions = {
+  SUBNET_MASK: 1,
+  ROUTER: 3,
+  DNS_SERVERS: 6,
+  MESSAGE_TYPE: 53,
+  SERVER_IDENTIFIER: 54,
+  LEASE_TIME: 51,
+  END: 255,
+} as const;
+
+export const DHCPOptionCodes = {
+  REQUESTED_IP: 50,
+  CLIENT_ID: 61,
+  SERVER_ID: 54,
+} as const;

--- a/packages/dhcp/src/dhcp-server.ts
+++ b/packages/dhcp/src/dhcp-server.ts
@@ -1,0 +1,219 @@
+import type { UdpDatagram, UdpSocket } from 'tcpip';
+import {
+  DHCP_CLIENT_PORT,
+  DHCP_SERVER_PORT,
+  DHCPMessageTypes,
+} from './constants.js';
+import type { DHCPLease, DHCPMessage, DHCPServerOptions } from './types.js';
+import { ipv4ToNumber, numberToIPv4 } from './util.js';
+import { parseDHCPMessage, serializeDHCPMessage } from './wire.js';
+
+export async function createDHCPServer(options: DHCPServerOptions) {
+  const server = new DHCPServer(options);
+  await server.listen();
+  return server;
+}
+
+export class DHCPServer {
+  leases = new Map<string, DHCPLease>();
+
+  #options: DHCPServerOptions;
+
+  constructor(options: DHCPServerOptions) {
+    this.#options = {
+      leaseDuration: 86400,
+      ...options,
+    };
+  }
+
+  async listen() {
+    const socket = await this.#options.stack.openUdp({
+      port: DHCP_SERVER_PORT,
+    });
+    this.#processDHCPMessages(socket);
+  }
+
+  async #processDHCPMessages(socket: UdpSocket) {
+    const writer = socket.writable.getWriter();
+
+    for await (const datagram of socket) {
+      // Process each message without blocking
+      this.#processDHCPMessage(datagram, writer);
+    }
+  }
+
+  async #processDHCPMessage(
+    datagram: UdpDatagram,
+    writer: WritableStreamDefaultWriter<UdpDatagram>
+  ) {
+    try {
+      const reply = this.#handleDHCPMessage(datagram.data);
+      if (reply) {
+        await writer.write(reply);
+      }
+    } catch (err) {
+      console.error('error processing DHCP message:', err);
+    }
+  }
+
+  #handleDHCPMessage(data: Uint8Array) {
+    const message = parseDHCPMessage(data);
+
+    switch (message.type) {
+      case 'DISCOVER':
+        return this.#handleDiscover(message);
+      case 'REQUEST':
+        return this.#handleRequest(message);
+      case 'RELEASE':
+        return this.#handleRelease(message);
+      default:
+        throw new Error(
+          `received unsupported DHCP client message type: ${message.type}`
+        );
+    }
+  }
+
+  #findAvailableIP(mac: string) {
+    const existingLease = this.leases.get(mac);
+    if (existingLease && existingLease.expiresAt > Date.now()) {
+      return existingLease.ip;
+    }
+
+    const start = ipv4ToNumber(this.#options.leaseRange.start);
+    const end = ipv4ToNumber(this.#options.leaseRange.end);
+
+    const usedIPs = new Set(
+      Array.from(this.leases.values()).map((lease) => lease.ip)
+    );
+
+    for (let i = start; i <= end; i++) {
+      const ip = numberToIPv4(i);
+      if (!usedIPs.has(ip)) {
+        return ip;
+      }
+    }
+  }
+
+  #handleDiscover(message: DHCPMessage): UdpDatagram {
+    const ip = this.#findAvailableIP(message.mac);
+    if (!ip) {
+      return this.#createNak(message);
+    }
+
+    const offer = serializeDHCPMessage(
+      {
+        op: 2,
+        xid: message.xid,
+        yiaddr: ip,
+        mac: message.mac,
+        type: DHCPMessageTypes.OFFER,
+      },
+      this.#options
+    );
+
+    return {
+      host: '255.255.255.255',
+      port: DHCP_CLIENT_PORT,
+      data: offer,
+    };
+  }
+
+  #handleRequest(message: DHCPMessage): UdpDatagram | undefined {
+    // Determine if this is a response to our offer or a direct request
+    const isResponseToOffer =
+      message.serverIdentifier === this.#options.serverIdentifier;
+
+    let assignedIp: string | undefined = undefined;
+
+    if (isResponseToOffer) {
+      // Client is accepting our offer
+      assignedIp = this.#findAvailableIP(message.mac);
+      if (!assignedIp) {
+        return this.#createNak(message);
+      }
+    } else if (message.requestedIp) {
+      // Client is requesting a specific IP
+      const canUseRequestedIp = this.#canUseRequestedIP(
+        message.requestedIp,
+        message.mac
+      );
+      if (canUseRequestedIp) {
+        assignedIp = message.requestedIp;
+      } else {
+        return this.#createNak(message);
+      }
+    } else {
+      // Malformed REQUEST - no way to know what IP to assign
+      return this.#createNak(message);
+    }
+
+    // If we got here, we have a valid IP to assign
+    this.leases.set(message.mac, {
+      ip: assignedIp,
+      mac: message.mac,
+      expiresAt: Date.now() + this.#options.leaseDuration! * 1000,
+    });
+
+    const ack = serializeDHCPMessage(
+      {
+        op: 2,
+        xid: message.xid,
+        yiaddr: assignedIp,
+        mac: message.mac,
+        type: DHCPMessageTypes.ACK,
+      },
+      this.#options
+    );
+
+    return {
+      host: '255.255.255.255',
+      port: DHCP_CLIENT_PORT,
+      data: ack,
+    };
+  }
+
+  #handleRelease(message: DHCPMessage) {
+    this.leases.delete(message.mac);
+  }
+
+  #createNak(message: DHCPMessage): UdpDatagram {
+    const nak = serializeDHCPMessage(
+      {
+        op: 2,
+        xid: message.xid,
+        yiaddr: '0.0.0.0', // No IP assigned in NAK
+        mac: message.mac,
+        type: DHCPMessageTypes.NAK,
+      },
+      this.#options
+    );
+
+    return {
+      host: '255.255.255.255',
+      port: DHCP_CLIENT_PORT,
+      data: nak,
+    };
+  }
+
+  #canUseRequestedIP(requestedIp: string, clientMac: string): boolean {
+    // Check if IP is in our range
+    const ipNum = ipv4ToNumber(requestedIp);
+    const rangeStart = ipv4ToNumber(this.#options.leaseRange.start);
+    const rangeEnd = ipv4ToNumber(this.#options.leaseRange.end);
+
+    if (ipNum < rangeStart || ipNum > rangeEnd) {
+      return false;
+    }
+
+    // Check if IP is in use by another client
+    for (const [mac, lease] of this.leases.entries()) {
+      if (lease.ip === requestedIp) {
+        // IP is in use, but check if it's by this same client
+        return mac === clientMac && lease.expiresAt > Date.now();
+      }
+    }
+
+    // IP is in our range and not in use
+    return true;
+  }
+}

--- a/packages/dhcp/src/index.ts
+++ b/packages/dhcp/src/index.ts
@@ -1,0 +1,2 @@
+export * from './dhcp-server.js';
+export type { DHCPLease, DHCPServerOptions } from './types.js';

--- a/packages/dhcp/src/types.ts
+++ b/packages/dhcp/src/types.ts
@@ -1,0 +1,70 @@
+import type { NetworkStack } from 'tcpip';
+import type { DHCPMessageTypes, DHCPOptions } from './constants.js';
+
+export type DHCPMessageType = keyof typeof DHCPMessageTypes;
+export type DHCPOption = keyof typeof DHCPOptions;
+
+export type DHCPLease = {
+  ip: string;
+  mac: string;
+  expiresAt: number;
+};
+
+export type DHCPMessageParams = {
+  op: number;
+  xid: number;
+  yiaddr: string;
+  mac: string;
+  type: number;
+};
+
+export type DHCPMessage = {
+  op: number;
+  htype: number;
+  hlen: number;
+  xid: number;
+  mac: string;
+  type?: DHCPMessageType;
+  requestedIp?: string;
+  serverIdentifier?: string;
+};
+
+export type DHCPServerOptions = {
+  /**
+   * `tcpip` network stack to use.
+   */
+  stack: NetworkStack;
+
+  /**
+   * Range of IP addresses to lease.
+   */
+  leaseRange: {
+    start: string;
+    end: string;
+  };
+
+  /**
+   * Duration of a lease in seconds.
+   */
+  leaseDuration?: number;
+
+  /**
+   * IP address of the DHCP server.
+   */
+  serverIdentifier: string;
+
+  /**
+   * Subnet mask to assign to clients.
+   */
+  subnetMask: string;
+
+  /**
+   * IP address of the router to assign to clients.
+   */
+  router: string;
+
+  /**
+   * IP addresses of DNS servers to assign to clients.
+   */
+  dnsServers?: string[];
+};

--- a/packages/dhcp/src/util.ts
+++ b/packages/dhcp/src/util.ts
@@ -1,0 +1,22 @@
+/**
+ * Convert an IPv4 address string to a 32-bit number.
+ */
+export function ipv4ToNumber(ip: string): number {
+  return (
+    ip
+      .split('.')
+      .reduce((sum, octet) => (sum << 8) + parseInt(octet, 10), 0) >>> 0
+  );
+}
+
+/**
+ * Convert a 32-bit number to an IPv4 address string.
+ */
+export function numberToIPv4(num: number): string {
+  return [
+    (num >>> 24) & 255,
+    (num >>> 16) & 255,
+    (num >>> 8) & 255,
+    num & 255,
+  ].join('.');
+}

--- a/packages/dhcp/src/wire.ts
+++ b/packages/dhcp/src/wire.ts
@@ -1,0 +1,178 @@
+import { DHCPMessageTypes, DHCPOptionCodes, DHCPOptions } from './constants.js';
+import type {
+  DHCPMessage,
+  DHCPMessageParams,
+  DHCPMessageType,
+  DHCPOption,
+  DHCPServerOptions,
+} from './types.js';
+import { ipv4ToNumber, numberToIPv4 } from './util.js';
+
+export function parseDHCPMessageType(type: number) {
+  const [key] =
+    Object.entries(DHCPMessageTypes).find(([, value]) => value === type) ?? [];
+
+  if (!key) {
+    throw new Error(`unknown dhcp message type: ${type}`);
+  }
+
+  return key as DHCPMessageType;
+}
+
+export function serializeDHCPMessageType(type: DHCPMessageType) {
+  return DHCPMessageTypes[type];
+}
+
+export function parseDHCPOption(option: number) {
+  const [key] =
+    Object.entries(DHCPOptions).find(([, value]) => value === option) ?? [];
+
+  if (!key) {
+    throw new Error(`unknown dhcp option: ${option}`);
+  }
+
+  return key as DHCPOption;
+}
+
+export function serializeDHCPOption(option: DHCPOption) {
+  return DHCPOptions[option];
+}
+
+export function parseDHCPMessage(data: Uint8Array): DHCPMessage {
+  if (data.length < 240) {
+    throw new Error('dhcp message too short');
+  }
+
+  const view = new DataView(data.buffer);
+
+  const op = view.getUint8(0);
+  const htype = view.getUint8(1);
+  const hlen = view.getUint8(2);
+  const xid = view.getUint32(4);
+
+  // Get the client's MAC address from the chaddr field
+  const macBytes = new Uint8Array(data.buffer, 28, 6);
+  const mac = Array.from(macBytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join(':');
+
+  // Parse DHCP options section
+  let type: DHCPMessageType | undefined;
+  let requestedIp: string | undefined;
+  let serverIdentifier: string | undefined;
+
+  let i = 240; // Start of options section
+  while (i < data.length) {
+    const option = data[i];
+    if (option === DHCPOptions.END) break;
+
+    const len = data[i + 1]!;
+
+    switch (option) {
+      case DHCPOptions.MESSAGE_TYPE:
+        type = parseDHCPMessageType(data[i + 2]!);
+        break;
+      case DHCPOptionCodes.REQUESTED_IP: {
+        const ip = view.getUint32(i + 2);
+        requestedIp = numberToIPv4(ip);
+        break;
+      }
+      case DHCPOptionCodes.SERVER_ID:
+        serverIdentifier = Array.from(data.slice(i + 2, i + 2 + 4)).join('.');
+        break;
+    }
+
+    i += len + 2; // Move to next option
+  }
+
+  return {
+    op,
+    htype,
+    hlen,
+    xid,
+    mac,
+    type,
+    requestedIp,
+    serverIdentifier,
+  };
+}
+
+export function serializeDHCPMessage(
+  params: DHCPMessageParams,
+  options: DHCPServerOptions
+): Uint8Array {
+  const baseSize = 240;
+  const optionsSize = 64 + (options.dnsServers?.length ?? 0) * 4;
+  const message = new Uint8Array(baseSize + optionsSize);
+  const view = new DataView(message.buffer);
+
+  // Set message header fields
+  view.setUint8(0, params.op);
+  view.setUint8(1, 1);
+  view.setUint8(2, 6);
+  view.setUint32(4, params.xid);
+
+  // Set yiaddr (your IP) field
+  const ip = ipv4ToNumber(params.yiaddr);
+  view.setUint32(16, ip);
+
+  // Set client MAC address
+  const macBytes = params.mac.split(':').map((x: string) => parseInt(x, 16));
+  for (let i = 0; i < 6; i++) {
+    view.setUint8(28 + i, macBytes[i]!);
+  }
+
+  // Set DHCP magic cookie
+  view.setUint32(236, 0x63825363);
+
+  let offset = 240;
+
+  // Message type option
+  message[offset++] = DHCPOptions.MESSAGE_TYPE;
+  message[offset++] = 1;
+  message[offset++] = params.type;
+
+  // Server identifier
+  message[offset++] = DHCPOptions.SERVER_IDENTIFIER;
+  message[offset++] = 4;
+
+  const serverIP = ipv4ToNumber(options.serverIdentifier);
+  view.setUint32(offset, serverIP);
+  offset += 4;
+
+  // Lease time
+  message[offset++] = DHCPOptions.LEASE_TIME;
+  message[offset++] = 4;
+  view.setUint32(offset, options.leaseDuration!);
+  offset += 4;
+
+  // Subnet mask
+  message[offset++] = DHCPOptions.SUBNET_MASK;
+  message[offset++] = 4;
+  const mask = ipv4ToNumber(options.subnetMask);
+  view.setUint32(offset, mask);
+  offset += 4;
+
+  // Router
+  message[offset++] = DHCPOptions.ROUTER;
+  message[offset++] = 4;
+  const router = ipv4ToNumber(options.router);
+  view.setUint32(offset, router);
+  offset += 4;
+
+  // DNS Servers (if configured)
+  if (options.dnsServers?.length) {
+    message[offset++] = DHCPOptions.DNS_SERVERS;
+    message[offset++] = 4 * options.dnsServers.length;
+    for (const dnsServer of options.dnsServers) {
+      const dnsIP = ipv4ToNumber(dnsServer);
+      view.setUint32(offset, dnsIP);
+      offset += 4;
+    }
+  }
+
+  // End option
+  message[offset++] = DHCPOptions.END;
+
+  return message.slice(0, offset);
+}

--- a/packages/dhcp/tsconfig.json
+++ b/packages/dhcp/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@total-typescript/tsconfig/bundler/dom/library",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/dhcp/tsup.config.ts
+++ b/packages/dhcp/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    outDir: 'dist',
+    sourcemap: true,
+    dts: true,
+    minify: true,
+    splitting: true,
+  },
+]);

--- a/packages/dhcp/vitest.config.ts
+++ b/packages/dhcp/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.{test,spec}.ts'],
+  },
+});


### PR DESCRIPTION
Adds a basic DHCP server. Handles `DISCOVER`, `REQUEST`, and `RELEASE` messages. Can be configured with the following options:

- `leaseRange`: Range of IP addresses to lease.
- `leaseDuration`: Duration of a lease in seconds.
- `serverIdentifier`: IP address of the DHCP server.
- `subnetMask`: Subnet mask to assign to clients.
- `router`: IP address of the default gateway to assign to clients.
- `dnsServers`: IP addresses of DNS servers to assign to clients.

And can be used like this:

```ts
import { createStack } from 'tcpip';
import { createDHCPServer } from '@tcpip/dhcp';

const stack = await createStack();

const tapInterface = await stack.createTapInterface({
  ip: '10.0.0.1/24',
  mac: '02:00:00:00:00:01',
});

const dhcpServer = await createDHCPServer({
  stack,
  leaseRange: {
    start: '10.0.0.100',
    end: '10.0.0.200',
  },
  serverIdentifier: '10.0.0.1',
  subnetMask: '255.255.255.0',
  router: '10.0.0.1',
  leaseDuration: 86400, // 24 hours
  dnsServers: ['10.0.0.1'], // Assuming we also host a DNS server on the tcpip stack
});
```

Active leases can be accessed via `dhcpServer.leases` `Map`:

```ts
type DHCPLease = {
  ip: string;
  mac: string;
  expiresAt: number;
};

// `leases` is a `Map` of MAC addresses to a `DHCPLease`
const { ip } = dhcpServer.leases.get('02:00:00:00:00:02');
```