### PR TITLE
feat: adds wabt container to help with wasm debugging

### DIFF
--- a/packages/tcpip/docker-compose.yml
+++ b/packages/tcpip/docker-compose.yml
@@ -14,3 +14,12 @@ services:
     working_dir: /work
     volumes:
       - $PWD:/work
+  wabt:
+    image: wabt
+    container_name: wabt-container
+    build:
+      context: tools/wabt
+      dockerfile: Dockerfile
+    working_dir: /work
+    volumes:
+      - $PWD:/work

--- a/packages/tcpip/package.json
+++ b/packages/tcpip/package.json
@@ -16,6 +16,7 @@
     "test": "vitest",
     "clean": "rm -rf dist",
     "make": "CC='docker compose run --rm wasi-sdk /opt/wasi-sdk/bin/clang' AR='docker compose run --rm wasi-sdk /opt/wasi-sdk/bin/ar' make",
+    "wasm-objdump": "docker compose run --rm wabt wasm-objdump",
     "wasm-opt": "docker compose run --rm binaryen wasm-opt -Oz --enable-bulk-memory wasm/tcpip.wasm -o wasm/tcpip.min.wasm"
   },
   "files": [

--- a/packages/tcpip/tools/wabt/Dockerfile
+++ b/packages/tcpip/tools/wabt/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:bookworm
+
+ARG WABT_VERSION=1.0.36
+
+RUN apt-get update && apt-get install -y \
+  git \
+  g++ \
+  cmake \
+  python3 \
+  ninja-build
+
+RUN git clone --branch ${WABT_VERSION} --depth 1 https://github.com/WebAssembly/wabt /wabt && \
+  cd /wabt && \
+  git submodule update --init && \
+  mkdir build
+
+WORKDIR /wabt/build
+
+RUN cmake .. && \
+  cmake --build .
+
+ENV PATH="/wabt/build:${PATH}"


### PR DESCRIPTION
The [WebAssembly Binary Toolkit](https://github.com/WebAssembly/wabt) (wabt) is a suite of tools for WebAssembly that can help process/debug WASM files.

This adds a `wabt` image/container that provides access to these tools. Eg:

```shell
$ npm run wasm-objdump -- -x tcpip.wasm
```