### PR TITLE
Bridge interface

### DIFF
--- a/packages/tcpip/src/bindings/base.ts
+++ b/packages/tcpip/src/bindings/base.ts
@@ -20,8 +20,9 @@ export abstract class Bindings<Imports, Exports> {
     return new UniquePointer(this.exports.malloc(size), this.exports.free);
   }
 
-  copyToMemory(data: Uint8Array) {
-    const length = data.length;
+  copyToMemory(data: ArrayBuffer) {
+    const bytes = new Uint8Array(data);
+    const length = bytes.length;
     const pointer = this.smartMalloc(length);
 
     const memoryView = new Uint8Array(
@@ -30,7 +31,7 @@ export abstract class Bindings<Imports, Exports> {
       length
     );
 
-    memoryView.set(data);
+    memoryView.set(bytes);
 
     return pointer;
   }

--- a/packages/tcpip/src/bindings/bridge-interface.ts
+++ b/packages/tcpip/src/bindings/bridge-interface.ts
@@ -1,0 +1,79 @@
+import { serializeMacAddress, type MacAddress } from '../protocols/ethernet.js';
+import { serializeIPv4Cidr, type IPv4Cidr } from '../protocols/ipv4.js';
+import type { Pointer } from '../types.js';
+import { generateMacAddress } from '../util.js';
+import { Bindings } from './base.js';
+import { tapInterfaceHooks, type TapInterface } from './tap-interface.js';
+
+type BridgeInterfaceHandle = Pointer;
+
+export type BridgeImports = {};
+
+export type BridgeExports = {
+  create_bridge_interface(
+    macAddress: Pointer,
+    ipAddress: Pointer,
+    netmask: Pointer,
+    ports: Pointer,
+    ports_length: number
+  ): BridgeInterfaceHandle;
+  remove_bridge_interface(handle: BridgeInterfaceHandle): void;
+};
+
+export class BridgeBindings extends Bindings<BridgeImports, BridgeExports> {
+  interfaces = new Map<BridgeInterfaceHandle, BridgeInterface>();
+
+  imports = {};
+
+  async create(options: BridgeInterfaceOptions) {
+    const macAddress = options.mac
+      ? serializeMacAddress(options.mac)
+      : generateMacAddress();
+
+    const { ipAddress, netmask } = options.ip
+      ? serializeIPv4Cidr(options.ip)
+      : {};
+
+    using macAddressPtr = this.copyToMemory(macAddress);
+    using ipAddressPtr = ipAddress ? this.copyToMemory(ipAddress) : undefined;
+    using netmaskPtr = netmask ? this.copyToMemory(netmask) : undefined;
+    const portHandles = new Uint32Array(
+      options.ports.map((port) =>
+        Number(tapInterfaceHooks.getOuter(port).handle)
+      )
+    );
+
+    using portHandlesPtr = this.copyToMemory(portHandles.buffer);
+
+    const handle = this.exports.create_bridge_interface(
+      macAddressPtr,
+      ipAddressPtr ?? 0,
+      netmaskPtr ?? 0,
+      portHandlesPtr,
+      options.ports.length
+    );
+
+    const bridgeInterface = new BridgeInterface();
+    this.interfaces.set(handle, bridgeInterface);
+
+    return bridgeInterface;
+  }
+
+  async remove(bridgeInterface: BridgeInterface) {
+    for (const [handle, loopback] of this.interfaces.entries()) {
+      if (loopback === bridgeInterface) {
+        this.exports.remove_bridge_interface(handle);
+        this.interfaces.delete(handle);
+        return;
+      }
+    }
+  }
+}
+
+export type BridgeInterfaceOptions = {
+  ports: TapInterface[];
+  mac?: MacAddress;
+  ip?: IPv4Cidr;
+};
+
+export class BridgeInterface {}

--- a/packages/tcpip/src/bindings/loopback-interface.ts
+++ b/packages/tcpip/src/bindings/loopback-interface.ts
@@ -30,14 +30,16 @@ export class LoopbackBindings extends Bindings<
   };
 
   async create(options: LoopbackInterfaceOptions) {
-    const { ipAddress, netmask } = serializeIPv4Cidr(options.ip);
+    const { ipAddress, netmask } = options.ip
+      ? serializeIPv4Cidr(options.ip)
+      : {};
 
-    using ipAddressPtr = this.copyToMemory(ipAddress);
-    using netmaskPtr = this.copyToMemory(netmask);
+    using ipAddressPtr = ipAddress ? this.copyToMemory(ipAddress) : undefined;
+    using netmaskPtr = netmask ? this.copyToMemory(netmask) : undefined;
 
     const handle = this.exports.create_loopback_interface(
-      ipAddressPtr,
-      netmaskPtr
+      ipAddressPtr ?? 0,
+      netmaskPtr ?? 0
     );
 
     const loopbackInterface = this.interfaces.get(handle);
@@ -61,6 +63,6 @@ export class LoopbackBindings extends Bindings<
 }
 
 export type LoopbackInterfaceOptions = {
-  ip: IPv4Cidr;
+  ip?: IPv4Cidr;
 };
 export class LoopbackInterface {}

--- a/packages/tcpip/src/bindings/tap-interface.ts
+++ b/packages/tcpip/src/bindings/tap-interface.ts
@@ -16,8 +16,6 @@ type TapInterfaceHandle = Pointer;
 type TapInterfaceOuterHooks = {
   handle: TapInterfaceHandle;
   sendFrame(frame: Uint8Array): void;
-  enable(): void;
-  disable(): void;
 };
 
 type TapInterfaceInnerHooks = {
@@ -75,12 +73,6 @@ export class TapBindings extends Bindings<TapImports, TapExports> {
           if (result !== LwipError.ERR_OK) {
             throw new Error(`failed to send frame: ${result}`);
           }
-        },
-        enable: () => {
-          this.exports.enable_tap_interface(handle);
-        },
-        disable: () => {
-          this.exports.disable_tap_interface(handle);
         },
       });
 
@@ -198,14 +190,6 @@ export class TapInterface {
         }
       },
     });
-  }
-
-  enable() {
-    tapInterfaceHooks.getOuter(this).enable();
-  }
-
-  disable() {
-    tapInterfaceHooks.getOuter(this).disable();
   }
 
   listen() {

--- a/packages/tcpip/src/bindings/tap-interface.ts
+++ b/packages/tcpip/src/bindings/tap-interface.ts
@@ -186,7 +186,7 @@ export class TapInterface {
         try {
           tapInterfaceHooks.getOuter(this).sendFrame(packet);
         } catch (err) {
-          console.log('tap interface send failed', err);
+          console.error('tap interface send failed', err);
         }
       },
     });

--- a/packages/tcpip/src/bindings/tun-interface.ts
+++ b/packages/tcpip/src/bindings/tun-interface.ts
@@ -87,12 +87,17 @@ export class TunBindings extends Bindings<TunImports, TunExports> {
   };
 
   async create(options: TunInterfaceOptions) {
-    const { ipAddress, netmask } = serializeIPv4Cidr(options.ip);
+    const { ipAddress, netmask } = options.ip
+      ? serializeIPv4Cidr(options.ip)
+      : {};
 
-    using ipAddressPtr = this.copyToMemory(ipAddress);
-    using netmaskPtr = this.copyToMemory(netmask);
+    using ipAddressPtr = ipAddress ? this.copyToMemory(ipAddress) : undefined;
+    using netmaskPtr = netmask ? this.copyToMemory(netmask) : undefined;
 
-    const handle = this.exports.create_tun_interface(ipAddressPtr, netmaskPtr);
+    const handle = this.exports.create_tun_interface(
+      ipAddressPtr ?? 0,
+      netmaskPtr ?? 0
+    );
 
     const tunInterface = this.interfaces.get(handle);
 
@@ -115,7 +120,7 @@ export class TunBindings extends Bindings<TunImports, TunExports> {
 }
 
 export type TunInterfaceOptions = {
-  ip: IPv4Cidr;
+  ip?: IPv4Cidr;
 };
 
 export class TunInterface {

--- a/packages/tcpip/src/index.ts
+++ b/packages/tcpip/src/index.ts
@@ -17,6 +17,11 @@ export {
 } from './bindings/tap-interface.js';
 
 export {
+  BridgeInterface,
+  type BridgeInterfaceOptions,
+} from './bindings/bridge-interface.js';
+
+export {
   TcpConnection,
   TcpListener,
   type TcpConnectionOptions,

--- a/packages/tcpip/src/stack.test.ts
+++ b/packages/tcpip/src/stack.test.ts
@@ -5,6 +5,7 @@ import {
   SEND_BUFFER_SIZE,
 } from './bindings/tcp.js';
 import {
+  BridgeInterface,
   createStack,
   LoopbackInterface,
   TapInterface,
@@ -227,6 +228,90 @@ describe('createTapInterface', () => {
     expect(parsedFrame.payload.senderIP).toBe('192.168.1.1');
     expect(parsedFrame.payload.targetMac).toBe('00:1a:2b:3c:4d:5f');
     expect(parsedFrame.payload.targetIP).toBe('192.168.1.2');
+  });
+});
+
+describe('createBridgeInterface', () => {
+  test('should create a BridgeInterface with the given options', async () => {
+    const stack = await createStack();
+
+    const port1 = await stack.createTapInterface({
+      mac: '02:00:00:00:00:01',
+      ip: '192.168.1.2/24',
+    });
+
+    const port2 = await stack.createTapInterface({
+      mac: '02:00:00:00:00:02',
+      ip: '192.168.1.3/24',
+    });
+
+    const bridgeInterface = await stack.createBridgeInterface({
+      ports: [port1, port2],
+      mac: '02:00:00:00:00:00',
+      ip: '192.168.1.1/24',
+    });
+
+    expect(bridgeInterface).toBeInstanceOf(BridgeInterface);
+  });
+
+  test('frames are forwarded between ports', async () => {
+    // Create a network of two devices connected to a router
+    const device1 = await createStack();
+    const device2 = await createStack();
+    const router = await createStack();
+
+    const device1Tap = await device1.createTapInterface({
+      ip: '192.168.1.2/24',
+    });
+
+    const device2Tap = await device2.createTapInterface({
+      ip: '192.168.1.3/24',
+    });
+
+    const port1 = await router.createTapInterface();
+    const port2 = await router.createTapInterface();
+
+    // Bridge the two router ports
+    await router.createBridgeInterface({
+      ports: [port1, port2],
+      ip: '192.168.1.1/24',
+    });
+
+    // Connect device 1 to port 1
+    device1Tap.readable.pipeTo(port1.writable);
+    port1.readable.pipeTo(device1Tap.writable);
+
+    // Connect device 2 to port 2
+    device2Tap.readable.pipeTo(port2.writable);
+    port2.readable.pipeTo(device2Tap.writable);
+
+    // Listen on device 2
+    const listener = await device2.listenTcp({
+      port: 8080,
+    });
+
+    // Attempt to connect from device 1 to device 2 via bridge
+    const connection = await device1.connectTcp({
+      host: '192.168.1.3',
+      port: 8080,
+    });
+
+    // Write data to confirm communication
+    const outboundWriter = connection.writable.getWriter();
+    const data = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+    outboundWriter.write(data);
+
+    for await (const inbound of listener) {
+      const reader = inbound.readable.getReader();
+      const received = await reader.read();
+
+      if (received.done) {
+        throw new Error('expected value');
+      }
+
+      expect(received.value).toStrictEqual(data);
+      break;
+    }
   });
 });
 

--- a/packages/tcpip/src/stack.ts
+++ b/packages/tcpip/src/stack.ts
@@ -1,5 +1,9 @@
 import { ConsoleStdout, File, OpenFile, WASI } from '@bjorn3/browser_wasi_shim';
 import {
+  BridgeBindings,
+  type BridgeInterfaceOptions,
+} from './bindings/bridge-interface.js';
+import {
   LoopbackBindings,
   LoopbackInterface,
   type LoopbackInterfaceOptions,
@@ -40,6 +44,7 @@ export class NetworkStack {
   #loopbackBindings = new LoopbackBindings();
   #tunBindings = new TunBindings();
   #tapBindings = new TapBindings();
+  #bridgeBindings = new BridgeBindings();
   #tcpBindings = new TcpBindings();
   #udpBindings = new UdpBindings();
 
@@ -92,6 +97,7 @@ export class NetworkStack {
         ...this.#loopbackBindings.imports,
         ...this.#tunBindings.imports,
         ...this.#tapBindings.imports,
+        ...this.#bridgeBindings.imports,
         ...this.#tcpBindings.imports,
         ...this.#udpBindings.imports,
       },
@@ -102,6 +108,7 @@ export class NetworkStack {
     this.#loopbackBindings.register(wasmInstance.exports);
     this.#tunBindings.register(wasmInstance.exports);
     this.#tapBindings.register(wasmInstance.exports);
+    this.#bridgeBindings.register(wasmInstance.exports);
     this.#tcpBindings.register(wasmInstance.exports);
     this.#udpBindings.register(wasmInstance.exports);
 
@@ -142,10 +149,15 @@ export class NetworkStack {
   }
 
   async createTapInterface(
-    options: TapInterfaceOptions
+    options: TapInterfaceOptions = {}
   ): Promise<TapInterface> {
     await this.ready;
     return this.#tapBindings.create(options);
+  }
+
+  async createBridgeInterface(options: BridgeInterfaceOptions) {
+    await this.ready;
+    return this.#bridgeBindings.create(options);
   }
 
   async removeInterface(

--- a/packages/tcpip/src/types.ts
+++ b/packages/tcpip/src/types.ts
@@ -1,3 +1,4 @@
+import type { BridgeExports } from './bindings/bridge-interface.js';
 import type {
   LoopbackExports,
   LoopbackInterface,
@@ -8,7 +9,7 @@ import type { TunExports, TunInterface } from './bindings/tun-interface.js';
 import type { UdpExports } from './bindings/udp.js';
 import type { UniquePointer } from './util.js';
 
-export type Pointer = UniquePointer;
+export type Pointer = UniquePointer | 0;
 
 export type WasiExports = {
   memory: WebAssembly.Memory;
@@ -31,6 +32,7 @@ export type WasmExports = WasiExports &
   LoopbackExports &
   TunExports &
   TapExports &
+  BridgeExports &
   TcpExports &
   UdpExports;
 

--- a/packages/tcpip/src/util.test.ts
+++ b/packages/tcpip/src/util.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test, vi } from 'vitest';
+import { generateMacAddress } from './util';
+
+describe('generateMacAddress', () => {
+  test('should generate a MAC address of length 6', () => {
+    const mac = generateMacAddress();
+    expect(mac).toHaveLength(6);
+  });
+
+  test('should set the locally administered bit and clear the unicast bit', () => {
+    const mac = generateMacAddress();
+    // Check that the locally administered bit (bit 1) is set to 1
+    expect(mac[0]! & 0b00000010).toBe(0b00000010);
+    // Check that the unicast bit (bit 0) is set to 0
+    expect(mac[0]! & 0b00000001).toBe(0b00000000);
+  });
+
+  test('should generate different MAC addresses on subsequent calls', () => {
+    const mac1 = generateMacAddress();
+    const mac2 = generateMacAddress();
+    expect(mac1).not.toEqual(mac2);
+  });
+
+  test('should use crypto.getRandomValues to generate the MAC address', () => {
+    const spy = vi.spyOn(crypto, 'getRandomValues');
+    generateMacAddress();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/packages/tcpip/src/util.ts
+++ b/packages/tcpip/src/util.ts
@@ -215,3 +215,23 @@ export class ExtendedReadableStream<R> extends ReadableStream<R> {
 export async function nextMicrotask() {
   return await new Promise<void>((resolve) => queueMicrotask(resolve));
 }
+
+/**
+ * Generates a random MAC address.
+ *
+ * The generated address is locally administered (so won't conflict
+ * with real devices) and unicast (so it can be used as a source address).
+ */
+export function generateMacAddress() {
+  const mac = new Uint8Array(6);
+  crypto.getRandomValues(mac);
+
+  // Control bits only apply to the first byte
+  mac[0] =
+    // Clear the 2 least significant bits
+    (mac[0]! & 0b11111100) |
+    // Set locally administered bit (bit 1) to 1 and unicast bit (bit 0) to 0
+    0b00000010;
+
+  return mac;
+}

--- a/packages/tcpip/wasm/Filelists.mk
+++ b/packages/tcpip/wasm/Filelists.mk
@@ -3,6 +3,7 @@ SRC_FILES= \
 	$(SRC_DIR)/loopback_interface.c \
 	$(SRC_DIR)/tun_interface.c \
 	$(SRC_DIR)/tap_interface.c \
+	$(SRC_DIR)/bridge_interface.c \
 	$(SRC_DIR)/tcp.c \
 	$(SRC_DIR)/udp.c \
 	$(SRC_DIR)/arch.c

--- a/packages/tcpip/wasm/bridge_interface.c
+++ b/packages/tcpip/wasm/bridge_interface.c
@@ -13,12 +13,12 @@ struct netif *create_bridge_interface(const uint8_t mac_address[6], const uint8_
     return NULL;
   }
 
-  ip4_addr_t *ipaddr = NULL;
+  ip4_addr_t *ip4_addr = NULL;
   ip4_addr_t *netmask_addr = NULL;
 
   if (ip4) {
-    ipaddr = malloc(sizeof(ip4_addr_t));
-    IP4_ADDR(ipaddr, ip4[0], ip4[1], ip4[2], ip4[3]);
+    ip4_addr = malloc(sizeof(ip4_addr_t));
+    IP4_ADDR(ip4_addr, ip4[0], ip4[1], ip4[2], ip4[3]);
   }
 
   if (netmask) {
@@ -38,7 +38,7 @@ struct netif *create_bridge_interface(const uint8_t mac_address[6], const uint8_
       mac_address[5]);
 
   netif_add(netif,
-            ipaddr,
+            ip4_addr,
             netmask_addr,
             NULL,
             &bridge_init,

--- a/packages/tcpip/wasm/bridge_interface.c
+++ b/packages/tcpip/wasm/bridge_interface.c
@@ -1,0 +1,62 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "lwip/netif.h"
+#include "macros.h"
+#include "netif/bridgeif.h"
+
+EXPORT("create_bridge_interface")
+struct netif *create_bridge_interface(const uint8_t mac_address[6], const uint8_t ip4[4], const uint8_t netmask[4], struct netif *ports[], uint8_t ports_num) {
+  struct netif *netif = (struct netif *)malloc(sizeof(struct netif));
+
+  if (!netif) {
+    return NULL;
+  }
+
+  ip4_addr_t *ipaddr = NULL;
+  ip4_addr_t *netmask_addr = NULL;
+
+  if (ip4) {
+    ipaddr = malloc(sizeof(ip4_addr_t));
+    IP4_ADDR(ipaddr, ip4[0], ip4[1], ip4[2], ip4[3]);
+  }
+
+  if (netmask) {
+    netmask_addr = malloc(sizeof(ip4_addr_t));
+    IP4_ADDR(netmask_addr, netmask[0], netmask[1], netmask[2], netmask[3]);
+  }
+
+  bridgeif_initdata_t bridge_init = BRIDGEIF_INITDATA2(
+      ports_num,
+      1024,
+      16,
+      mac_address[0],
+      mac_address[1],
+      mac_address[2],
+      mac_address[3],
+      mac_address[4],
+      mac_address[5]);
+
+  netif_add(netif,
+            ipaddr,
+            netmask_addr,
+            NULL,
+            &bridge_init,
+            bridgeif_init,
+            netif_input);
+
+  netif_set_link_up(netif);
+  netif_set_up(netif);
+
+  for (uint8_t i = 0; i < ports_num; i++) {
+    bridgeif_add_port(netif, ports[i]);
+  }
+
+  return netif;
+}
+
+EXPORT("remove_bridge_interface")
+void remove_bridge_interface(struct netif *netif) {
+  netif_remove(netif);
+  free(netif);
+}

--- a/packages/tcpip/wasm/include/lwipopts.h
+++ b/packages/tcpip/wasm/include/lwipopts.h
@@ -2,11 +2,12 @@
 #define LWIPOPTS_H
 
 // System and threading options
-#define NO_SYS 1                // We are bare-metal/single-threaded
-#define SYS_LIGHTWEIGHT_PROT 0  // Disable thread protection (assumes NO_SYS=0)
-#define LWIP_SOCKET 0           // Disable socket API (assumes NO_SYS=0)
-#define LWIP_NETCONN 0          // Disable Netconn API (assumes NO_SYS=0)
-#define LWIP_NETIF_API 0        // Disable network interface API (assumes NO_SYS=0)
+#define NO_SYS 1                      // We are bare-metal/single-threaded
+#define SYS_LIGHTWEIGHT_PROT 0        // Disable thread protection (assumes NO_SYS=0)
+#define LWIP_SOCKET 0                 // Disable socket API (assumes NO_SYS=0)
+#define LWIP_NETCONN 0                // Disable Netconn API (assumes NO_SYS=0)
+#define LWIP_NETIF_API 0              // Disable network interface API (assumes NO_SYS=0)
+#define LWIP_NUM_NETIF_CLIENT_DATA 1  // Number of client data entries in struct netif (required for bridgeif)
 
 // Constants used for calculations
 #define TCP_HEADER_LEN 20  // Minimum length of a TCP header (in bytes)
@@ -30,6 +31,11 @@
 
 // Ethernet options
 #define LWIP_ARP 1  // Enable Address Resolution Protocol (ARP)
+
+// Bridging options
+// TODO: Change to 63 once this fix is merged:
+// https://github.com/lwip-tcpip/lwip/pull/56
+#define BRIDGEIF_MAX_PORTS 31  // Maximum number of ports in a bridge
 
 // IP options
 #define LWIP_IPV4 1   // Enable IPv4 support
@@ -60,15 +66,16 @@
 #define CHECKSUM_CHECK_ICMP 1  // Check checksums for incoming ICMP segments
 
 // Debugging options
-// #define LWIP_DEBUG 1                  // Enable debugging
-#define PBUF_DEBUG LWIP_DBG_ON        // Enable debugging for pbufs
-#define MEMP_DEBUG LWIP_DBG_ON        // Enable debugging for memory pools
-#define NETIF_DEBUG LWIP_DBG_ON       // Enable debugging for network interfaces
-#define ETHARP_DEBUG LWIP_DBG_ON      // Enable debugging for Ethernet ARP
-#define IP_DEBUG LWIP_DBG_ON          // Enable debugging for IP
-#define TCP_DEBUG LWIP_DBG_ON         // Enable debugging for TCP
-#define TCP_INPUT_DEBUG LWIP_DBG_ON   // Enable debugging for TCP input
-#define TCP_OUTPUT_DEBUG LWIP_DBG_ON  // Enable debugging for TCP input
-#define UDP_DEBUG LWIP_DBG_ON         // Enable debugging for UDP
+// #define LWIP_DEBUG 1                   // Enable debugging
+#define PBUF_DEBUG LWIP_DBG_ON         // Enable debugging for pbufs
+#define MEMP_DEBUG LWIP_DBG_ON         // Enable debugging for memory pools
+#define NETIF_DEBUG LWIP_DBG_ON        // Enable debugging for network interfaces
+#define BRIDGEIF_FW_DEBUG LWIP_DBG_ON  // Enable debugging for bridge forwarding
+#define ETHARP_DEBUG LWIP_DBG_ON       // Enable debugging for Ethernet ARP
+#define IP_DEBUG LWIP_DBG_ON           // Enable debugging for IP
+#define TCP_DEBUG LWIP_DBG_ON          // Enable debugging for TCP
+#define TCP_INPUT_DEBUG LWIP_DBG_ON    // Enable debugging for TCP input
+#define TCP_OUTPUT_DEBUG LWIP_DBG_ON   // Enable debugging for TCP input
+#define UDP_DEBUG LWIP_DBG_ON          // Enable debugging for UDP
 
 #endif /* LWIPOPTS_H */

--- a/packages/tcpip/wasm/include/lwipopts.h
+++ b/packages/tcpip/wasm/include/lwipopts.h
@@ -2,12 +2,13 @@
 #define LWIPOPTS_H
 
 // System and threading options
-#define NO_SYS 1                      // We are bare-metal/single-threaded
-#define SYS_LIGHTWEIGHT_PROT 0        // Disable thread protection (assumes NO_SYS=0)
-#define LWIP_SOCKET 0                 // Disable socket API (assumes NO_SYS=0)
-#define LWIP_NETCONN 0                // Disable Netconn API (assumes NO_SYS=0)
-#define LWIP_NETIF_API 0              // Disable network interface API (assumes NO_SYS=0)
-#define LWIP_NUM_NETIF_CLIENT_DATA 1  // Number of client data entries in struct netif (required for bridgeif)
+#define NO_SYS 1                                                  // We are bare-metal/single-threaded
+#define SYS_LIGHTWEIGHT_PROT 0                                    // Disable thread protection (assumes NO_SYS=0)
+#define LWIP_SOCKET 0                                             // Disable socket API (assumes NO_SYS=0)
+#define LWIP_NETCONN 0                                            // Disable Netconn API (assumes NO_SYS=0)
+#define LWIP_NETIF_API 0                                          // Disable network interface API (assumes NO_SYS=0)
+#define LWIP_NUM_NETIF_CLIENT_DATA 1                              // Number of client data entries in struct netif (required for bridgeif)
+#define MEMP_NUM_SYS_TIMEOUT (LWIP_NUM_SYS_TIMEOUT_INTERNAL + 1)  // Number of simultaneously active timeouts (default + 1 for bridgeif)
 
 // Constants used for calculations
 #define TCP_HEADER_LEN 20  // Minimum length of a TCP header (in bytes)

--- a/packages/tcpip/wasm/loopback_interface.c
+++ b/packages/tcpip/wasm/loopback_interface.c
@@ -20,20 +20,29 @@ static err_t netif_loopif_init(struct netif *netif) {
 }
 
 EXPORT("create_loopback_interface")
-struct netif *create_loopback_interface(const uint8_t *ip4, const uint8_t *netmask) {
+struct netif *create_loopback_interface(const uint8_t ip4[4], const uint8_t netmask[4]) {
   struct netif *netif = (struct netif *)malloc(sizeof(struct netif));
 
   if (!netif) {
     return NULL;
   }
 
-  ip4_addr_t ipaddr, netmask_addr;
-  IP4_ADDR(&ipaddr, ip4[0], ip4[1], ip4[2], ip4[3]);
-  IP4_ADDR(&netmask_addr, netmask[0], netmask[1], netmask[2], netmask[3]);
+  ip4_addr_t *ip4_addr = NULL;
+  ip4_addr_t *netmask_addr = NULL;
+
+  if (ip4) {
+    ip4_addr = malloc(sizeof(ip4_addr_t));
+    IP4_ADDR(ip4_addr, ip4[0], ip4[1], ip4[2], ip4[3]);
+  }
+
+  if (netmask) {
+    netmask_addr = malloc(sizeof(ip4_addr_t));
+    IP4_ADDR(netmask_addr, netmask[0], netmask[1], netmask[2], netmask[3]);
+  }
 
   register_loopback_interface(netif);
 
-  netif_add(netif, &ipaddr, &netmask_addr, NULL, NULL, netif_loopif_init, ip_input);
+  netif_add(netif, ip4_addr, netmask_addr, NULL, NULL, netif_loopif_init, ip_input);
 
   netif_set_link_up(netif);
   netif_set_up(netif);

--- a/packages/tcpip/wasm/loopback_interface.c
+++ b/packages/tcpip/wasm/loopback_interface.c
@@ -4,11 +4,7 @@
 #include "lwip/netif.h"
 #include "macros.h"
 
-typedef struct loopback_interface {
-  struct netif netif;
-} loopback_interface;
-
-extern void register_loopback_interface(loopback_interface *interface);
+extern void register_loopback_interface(struct netif *interface);
 
 static err_t netif_loop_output_ipv4(struct netif *netif, struct pbuf *p, const ip4_addr_t *addr) {
   LWIP_UNUSED_ARG(addr);
@@ -24,10 +20,10 @@ static err_t netif_loopif_init(struct netif *netif) {
 }
 
 EXPORT("create_loopback_interface")
-loopback_interface *create_loopback_interface(const uint8_t *ip4, const uint8_t *netmask) {
-  loopback_interface *interface = (loopback_interface *)malloc(sizeof(loopback_interface));
+struct netif *create_loopback_interface(const uint8_t *ip4, const uint8_t *netmask) {
+  struct netif *netif = (struct netif *)malloc(sizeof(struct netif));
 
-  if (!interface) {
+  if (!netif) {
     return NULL;
   }
 
@@ -35,18 +31,18 @@ loopback_interface *create_loopback_interface(const uint8_t *ip4, const uint8_t 
   IP4_ADDR(&ipaddr, ip4[0], ip4[1], ip4[2], ip4[3]);
   IP4_ADDR(&netmask_addr, netmask[0], netmask[1], netmask[2], netmask[3]);
 
-  register_loopback_interface(interface);
+  register_loopback_interface(netif);
 
-  netif_add(&interface->netif, &ipaddr, &netmask_addr, NULL, interface, netif_loopif_init, ip_input);
+  netif_add(netif, &ipaddr, &netmask_addr, NULL, NULL, netif_loopif_init, ip_input);
 
-  netif_set_link_up(&interface->netif);
-  netif_set_up(&interface->netif);
+  netif_set_link_up(netif);
+  netif_set_up(netif);
 
-  return interface;
+  return netif;
 }
 
 EXPORT("remove_loopback_interface")
-void remove_loopback_interface(loopback_interface *interface) {
-  netif_remove(&interface->netif);
-  free(interface);
+void remove_loopback_interface(struct netif *netif) {
+  netif_remove(netif);
+  free(netif);
 }

--- a/packages/tcpip/wasm/tap_interface.c
+++ b/packages/tcpip/wasm/tap_interface.c
@@ -90,13 +90,3 @@ err_t send_tap_interface(struct netif *netif, const uint8_t *frame, uint16_t len
 
   return err;
 }
-
-EXPORT("enable_tap_interface")
-void enable_tap_interface(struct netif *netif) {
-  netif_set_up(netif);
-}
-
-EXPORT("disable_tap_interface")
-void disable_tap_interface(struct netif *netif) {
-  netif_set_down(netif);
-}

--- a/packages/tcpip/wasm/tap_interface.c
+++ b/packages/tcpip/wasm/tap_interface.c
@@ -5,30 +5,15 @@
 #include "macros.h"
 #include "netif/etharp.h"
 
-typedef struct tap_interface {
-  struct netif netif;
-  uint8_t mac_address[6];
-  u16_t mtu;
-} tap_interface;
-
-extern void register_tap_interface(tap_interface *interface);
-extern void receive_frame(tap_interface *interface, const uint8_t *frame, uint16_t length);
+extern void register_tap_interface(struct netif *netif);
+extern void receive_frame(struct netif *netif, const uint8_t *frame, uint16_t length);
 
 err_t tap_interface_output(struct netif *netif, struct pbuf *p) {
-  receive_frame(netif->state, (uint8_t *)p->payload, p->tot_len);
+  receive_frame(netif, (uint8_t *)p->payload, p->tot_len);
   return 0;
 }
 
 static err_t tap_interface_init(struct netif *netif) {
-  tap_interface *interface = (tap_interface *)netif->state;
-
-  // Set MAC address
-  memcpy(netif->hwaddr, interface->mac_address, sizeof(interface->mac_address));
-  netif->hwaddr_len = sizeof(interface->mac_address);
-
-  // Set MTU
-  netif->mtu = interface->mtu;
-
   // Set interface flags
   netif->flags = NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP | NETIF_FLAG_ETHERNET;
 
@@ -42,47 +27,76 @@ static err_t tap_interface_init(struct netif *netif) {
 }
 
 EXPORT("create_tap_interface")
-tap_interface *create_tap_interface(const uint8_t mac_address[6], const uint8_t *ip4, const uint8_t *netmask) {
-  tap_interface *interface = (tap_interface *)malloc(sizeof(tap_interface));
+struct netif *create_tap_interface(const uint8_t mac_address[6], const uint8_t ip4[4], const uint8_t netmask[4]) {
+  struct netif *netif = (struct netif *)malloc(sizeof(struct netif));
 
-  if (!interface) {
+  if (!netif) {
     return NULL;
   }
 
-  // TODO: make MTU configurable
-  interface->mtu = 1500;
+  // Set MAC address
+  memcpy(netif->hwaddr, mac_address, 6);
+  netif->hwaddr_len = 6;
 
-  memcpy(interface->mac_address, mac_address, 6);
+  // Set MTU
+  // TODO: Make this configurable
+  netif->mtu = 1500;
 
-  ip4_addr_t ipaddr, netmask_addr;
-  IP4_ADDR(&ipaddr, ip4[0], ip4[1], ip4[2], ip4[3]);
-  IP4_ADDR(&netmask_addr, netmask[0], netmask[1], netmask[2], netmask[3]);
+  ip4_addr_t *ipaddr = NULL;
+  ip4_addr_t *netmask_addr = NULL;
 
-  register_tap_interface(interface);
+  if (ip4) {
+    ipaddr = malloc(sizeof(ip4_addr_t));
+    IP4_ADDR(ipaddr, ip4[0], ip4[1], ip4[2], ip4[3]);
+  }
 
-  netif_add(&interface->netif, &ipaddr, &netmask_addr, NULL, interface, tap_interface_init, netif_input);
-  netif_set_link_up(&interface->netif);
-  netif_set_up(&interface->netif);
+  if (netmask) {
+    netmask_addr = malloc(sizeof(ip4_addr_t));
+    IP4_ADDR(netmask_addr, netmask[0], netmask[1], netmask[2], netmask[3]);
+  }
 
-  return interface;
+  register_tap_interface(netif);
+
+  netif_add(netif, ipaddr, netmask_addr, NULL, NULL, tap_interface_init, netif_input);
+  netif_set_link_up(netif);
+  netif_set_up(netif);
+
+  return netif;
 }
 
 EXPORT("remove_tap_interface")
-void remove_tap_interface(tap_interface *interface) {
-  netif_remove(&interface->netif);
-  free(interface);
+void remove_tap_interface(struct netif *netif) {
+  netif_remove(netif);
+  free(netif);
 }
 
 EXPORT("send_tap_interface")
-void send_tap_interface(tap_interface *interface, const uint8_t *frame, uint16_t length) {
+err_t send_tap_interface(struct netif *netif, const uint8_t *frame, uint16_t length) {
   // Allocate a pbuf with PBUF_REF, pointing to frame buffer data
   struct pbuf *p = pbuf_alloc(PBUF_RAW, length, PBUF_REF);
-  if (p != NULL) {
-    p->payload = (void *)frame;
 
-    // Pass the pbuf to lwIP for processing
-    if (interface->netif.input(p, &interface->netif) != ERR_OK) {
-      pbuf_free(p);
-    }
+  if (p == NULL) {
+    return ERR_MEM;
   }
+
+  p->payload = (void *)frame;
+
+  err_t err = netif->input(p, netif);
+
+  // Pass the pbuf to lwIP for processing
+  if (err != ERR_OK) {
+    pbuf_free(p);
+  }
+
+  return err;
+}
+
+EXPORT("enable_tap_interface")
+void enable_tap_interface(struct netif *netif) {
+  netif_set_up(netif);
+}
+
+EXPORT("disable_tap_interface")
+void disable_tap_interface(struct netif *netif) {
+  netif_set_down(netif);
 }

--- a/packages/tcpip/wasm/tap_interface.c
+++ b/packages/tcpip/wasm/tap_interface.c
@@ -42,12 +42,12 @@ struct netif *create_tap_interface(const uint8_t mac_address[6], const uint8_t i
   // TODO: Make this configurable
   netif->mtu = 1500;
 
-  ip4_addr_t *ipaddr = NULL;
+  ip4_addr_t *ip4_addr = NULL;
   ip4_addr_t *netmask_addr = NULL;
 
   if (ip4) {
-    ipaddr = malloc(sizeof(ip4_addr_t));
-    IP4_ADDR(ipaddr, ip4[0], ip4[1], ip4[2], ip4[3]);
+    ip4_addr = malloc(sizeof(ip4_addr_t));
+    IP4_ADDR(ip4_addr, ip4[0], ip4[1], ip4[2], ip4[3]);
   }
 
   if (netmask) {
@@ -57,7 +57,7 @@ struct netif *create_tap_interface(const uint8_t mac_address[6], const uint8_t i
 
   register_tap_interface(netif);
 
-  netif_add(netif, ipaddr, netmask_addr, NULL, NULL, tap_interface_init, netif_input);
+  netif_add(netif, ip4_addr, netmask_addr, NULL, NULL, tap_interface_init, netif_input);
   netif_set_link_up(netif);
   netif_set_up(netif);
 

--- a/packages/tcpip/wasm/tun_interface.c
+++ b/packages/tcpip/wasm/tun_interface.c
@@ -20,20 +20,29 @@ static err_t tun_interface_init(struct netif *netif) {
 }
 
 EXPORT("create_tun_interface")
-struct netif *create_tun_interface(const uint8_t *ip4, const uint8_t *netmask) {
+struct netif *create_tun_interface(const uint8_t ip4[4], const uint8_t netmask[4]) {
   struct netif *netif = (struct netif *)malloc(sizeof(struct netif));
 
   if (!netif) {
     return NULL;
   }
 
-  ip4_addr_t ipaddr, netmask_addr;
-  IP4_ADDR(&ipaddr, ip4[0], ip4[1], ip4[2], ip4[3]);
-  IP4_ADDR(&netmask_addr, netmask[0], netmask[1], netmask[2], netmask[3]);
+  ip4_addr_t *ip4_addr = NULL;
+  ip4_addr_t *netmask_addr = NULL;
+
+  if (ip4) {
+    ip4_addr = malloc(sizeof(ip4_addr_t));
+    IP4_ADDR(ip4_addr, ip4[0], ip4[1], ip4[2], ip4[3]);
+  }
+
+  if (netmask) {
+    netmask_addr = malloc(sizeof(ip4_addr_t));
+    IP4_ADDR(netmask_addr, netmask[0], netmask[1], netmask[2], netmask[3]);
+  }
 
   register_tun_interface(netif);
 
-  netif_add(netif, &ipaddr, &netmask_addr, NULL, NULL, tun_interface_init, netif_input);
+  netif_add(netif, ip4_addr, netmask_addr, NULL, NULL, tun_interface_init, netif_input);
   netif_set_link_up(netif);
   netif_set_up(netif);
 


### PR DESCRIPTION
Adds a new type of interface: `BridgeInterface`. This allows you to bridge two or more tap interfaces together into a single logical interface with its own MAC and IP address and automatically forwarding frames between ports. This is useful for creating a virtual switch or a virtual router.