### PR TITLE
feat: dns client

### DIFF
--- a/packages/dns/src/constants.ts
+++ b/packages/dns/src/constants.ts
@@ -17,10 +17,17 @@ export const ClassCode = {
 
 export const OpCode = {
   QUERY: 0, // Standard query
+  IQUERY: 1, // Inverse query
+  STATUS: 2, // Server status request
+  NOTIFY: 4, // Notify
+  UPDATE: 5, // Update
 } as const;
 
 export const RCode = {
   NOERROR: 0, // No error
+  FORMERR: 1, // Format error
   SERVFAIL: 2, // Server failure
   NXDOMAIN: 3, // Non-existent domain
+  NOTIMP: 4, // Not implemented
+  REFUSED: 5, // Query refused
 } as const;

--- a/packages/dns/src/dns-client.ts
+++ b/packages/dns/src/dns-client.ts
@@ -1,0 +1,142 @@
+import type { IPv4Address } from '@tcpip/wire';
+import type { NetworkStack } from 'tcpip';
+import type { DnsMessage, DnsQuery, DnsRecord } from './types.js';
+import { ipToPtrName } from './util.js';
+import { parseDnsMessage, serializeDnsMessage } from './wire.js';
+
+export type DnsClientOptions = {
+  /**
+   * DNS server address to query.
+   * @default 127.0.0.1
+   */
+  server?: IPv4Address;
+
+  /**
+   * DNS server port.
+   * @default 53
+   */
+  port?: number;
+};
+
+export class DnsClient {
+  #stack: NetworkStack;
+  #options: Required<DnsClientOptions>;
+  #messageId = 0;
+
+  constructor(stack: NetworkStack, options: DnsClientOptions = {}) {
+    this.#stack = stack;
+    this.#options = {
+      port: 53,
+      server: '127.0.0.1',
+      ...options,
+    };
+  }
+
+  /**
+   * Send a DNS query and wait for the response.
+   */
+  async #query(query: DnsQuery): Promise<DnsRecord> {
+    // Create DNS message for query
+    const message: DnsMessage = {
+      header: {
+        id: this.#getNextMessageId(),
+        isResponse: false,
+        opcode: 'QUERY',
+        isAuthoritativeAnswer: false,
+        isTruncated: false,
+        isRecursionDesired: true,
+        isRecursionAvailable: false,
+        rcode: 'NOERROR',
+        questionCount: 0,
+        answerCount: 0,
+        authorityCount: 0,
+        additionalCount: 0,
+      },
+      questions: [
+        {
+          name: query.name,
+          type: query.type,
+          class: 'IN',
+        },
+      ],
+    };
+
+    const socket = await this.#stack.openUdp();
+
+    // Serialize and send the message
+    const data = serializeDnsMessage(message);
+    const writer = socket.writable.getWriter();
+
+    await writer.write({
+      host: this.#options.server,
+      port: this.#options.port,
+      data,
+    });
+
+    // Wait for and parse the response
+    for await (const datagram of socket) {
+      const response = parseDnsMessage(datagram.data);
+
+      // Verify this is the response to our query
+      if (response.header.id !== message.header.id) {
+        continue;
+      }
+
+      // Check for errors
+      if (response.header.rcode !== 'NOERROR') {
+        throw new Error(
+          `dns query failed with rcode: ${response.header.rcode}`
+        );
+      }
+
+      if (response.header.answerCount > 1) {
+        throw new Error('expected exactly one dns answer');
+      }
+
+      const [answer] = response.answers ?? [];
+
+      if (!answer) {
+        throw new Error('no dns answer found');
+      }
+
+      return answer;
+    }
+
+    throw new Error('udp socket closed before receiving response');
+  }
+
+  /**
+   * Performs an A record lookup to get the IP address for a hostname.
+   */
+  async lookup(name: string): Promise<string> {
+    const response = await this.#query({ name, type: 'A' });
+
+    if (!response || response.type !== 'A') {
+      throw new Error(`no A record found for ${name}`);
+    }
+
+    return response.ip;
+  }
+
+  /**
+   * Performs a reverse DNS (PTR) lookup to get the hostname for an IP address.
+   */
+  async reverse(ip: string): Promise<string> {
+    const ptrName = ipToPtrName(ip);
+    const response = await this.#query({ name: ptrName, type: 'PTR' });
+
+    if (!response || response.type !== 'PTR') {
+      throw new Error(`No PTR record found for ${ip}`);
+    }
+
+    return response.ptr;
+  }
+
+  /**
+   * Get the next message ID, cycling from 0-65535.
+   */
+  #getNextMessageId(): number {
+    this.#messageId = (this.#messageId + 1) % 65536;
+    return this.#messageId;
+  }
+}

--- a/packages/dns/src/dns-server.ts
+++ b/packages/dns/src/dns-server.ts
@@ -16,31 +16,22 @@ export type DnsServerOptions = {
   port?: number;
 
   /**
-   * `tcpip` network stack to use.
-   */
-  stack: NetworkStack;
-
-  /**
    * Callback function to handle DNS queries.
    */
   request: RequestFn;
 };
 
-export async function createDnsServer(options: DnsServerOptions) {
-  const server = new DnsServer(options);
-  await server.listen();
-  return server;
-}
-
 export class DnsServer {
+  #stack: NetworkStack;
   #options: DnsServerOptions;
 
-  constructor(options: DnsServerOptions) {
+  constructor(stack: NetworkStack, options: DnsServerOptions) {
+    this.#stack = stack;
     this.#options = options;
   }
 
   async listen() {
-    const socket = await this.#options.stack.openUdp({
+    const socket = await this.#stack.openUdp({
       port: this.#options.port ?? 53,
     });
     this.#processDnsMessages(socket);

--- a/packages/dns/src/index.test.ts
+++ b/packages/dns/src/index.test.ts
@@ -1,0 +1,78 @@
+import { createStack } from 'tcpip';
+import { describe, expect, test } from 'vitest';
+import { createDns, ptrNameToIP } from './index.js';
+
+describe('createDns', () => {
+  test('client and server can communicate', async () => {
+    const stack = await createStack();
+    const { lookup, serve } = await createDns(stack);
+
+    await serve({
+      request: async ({ name, type }) => {
+        if (name !== 'example.com' || type !== 'A') {
+          throw new Error(`unexpected test query: ${name} ${type}`);
+        }
+
+        return {
+          type,
+          ip: '10.0.0.1',
+          ttl: 300,
+        };
+      },
+    });
+
+    const ip = await lookup('example.com');
+
+    expect(ip).toBe('10.0.0.1');
+  });
+
+  test('reverse A lookup', async () => {
+    const stack = await createStack();
+    const { reverse, serve } = await createDns(stack);
+
+    await serve({
+      request: async ({ name, type }) => {
+        const { type: ptrType, ip } = ptrNameToIP(name);
+
+        if (type !== 'PTR' || ptrType !== 'ipv4' || ip !== '10.0.0.1') {
+          throw new Error(`unexpected test query: ${name} ${type}`);
+        }
+
+        return {
+          type,
+          ptr: 'example.com',
+          ttl: 300,
+        };
+      },
+    });
+
+    const name = await reverse('10.0.0.1');
+
+    expect(name).toBe('example.com');
+  });
+
+  test('reverse AAAA lookup', async () => {
+    const stack = await createStack();
+    const { reverse, serve } = await createDns(stack);
+
+    await serve({
+      request: async ({ name, type }) => {
+        const { type: ptrType, ip } = ptrNameToIP(name);
+
+        if (type !== 'PTR' || ptrType !== 'ipv6' || ip !== '2001:db8::1') {
+          throw new Error(`unexpected test query: ${name} ${type}`);
+        }
+
+        return {
+          type,
+          ptr: 'example.com',
+          ttl: 300,
+        };
+      },
+    });
+
+    const name = await reverse('2001:db8::1');
+
+    expect(name).toBe('example.com');
+  });
+});

--- a/packages/dns/src/index.ts
+++ b/packages/dns/src/index.ts
@@ -1,3 +1,41 @@
+import type { NetworkStack } from 'tcpip';
+import { DnsClient, type DnsClientOptions } from './dns-client.js';
+import { DnsServer, type DnsServerOptions } from './dns-server.js';
+
 export * from './dns-server.js';
 export type { DnsResponse, DnsType } from './types.js';
 export { ptrNameToIP } from './util.js';
+
+export type CreateDnsOptions = {
+  /**
+   * DNS client options.
+   */
+  client?: DnsClientOptions;
+};
+
+/**
+ * Creates DNS server and client functions on top of a
+ * `tcpip` network stack.
+ *
+ * @example
+ * const stack = await createStack();
+ * const { serve, lookup } = await createDns(stack);
+ * const server = await serve({ ... });
+ * const ip = await lookup('example.com');
+ */
+export async function createDns(
+  stack: NetworkStack,
+  options: CreateDnsOptions = {}
+) {
+  const client = new DnsClient(stack, options.client);
+
+  return {
+    serve: async (options: DnsServerOptions) => {
+      const server = new DnsServer(stack, options);
+      await server.listen();
+      return server;
+    },
+    lookup: async (name: string) => client.lookup(name),
+    reverse: async (ip: string) => client.reverse(ip),
+  };
+}

--- a/packages/dns/src/types.ts
+++ b/packages/dns/src/types.ts
@@ -96,7 +96,7 @@ export type DnsQuery = {
 export type DnsMessage = {
   header: DnsHeader;
   questions: DnsQuestion[];
-  answers: DnsRecord[];
-  authorities: DnsRecord[];
-  additionals: DnsRecord[];
+  answers?: DnsRecord[];
+  authorities?: DnsRecord[];
+  additionals?: DnsRecord[];
 };

--- a/packages/dns/src/util.test.ts
+++ b/packages/dns/src/util.test.ts
@@ -1,5 +1,26 @@
 import { describe, expect, test } from 'vitest';
-import { ptrNameToIP } from './util';
+import { ipToPtrName, ptrNameToIP } from './util';
+
+describe('ipToPtrName', () => {
+  test('should convert an IPv4 address to a PTR name', () => {
+    const ptr = ipToPtrName('10.0.0.1');
+    expect(ptr).toBe('1.0.0.10.in-addr.arpa');
+  });
+
+  test('should convert an IPv6 address to a PTR name', () => {
+    const ptr = ipToPtrName('2001:db8::567:89ab');
+    expect(ptr).toBe(
+      'b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa'
+    );
+  });
+
+  test('should handle compressed IPv6 addresses', () => {
+    const ptr = ipToPtrName('::1');
+    expect(ptr).toBe(
+      '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa'
+    );
+  });
+});
 
 describe('ptrNameToIP', () => {
   test('should convert PTR name to an IPv4 address', () => {

--- a/packages/dns/src/wire.test.ts
+++ b/packages/dns/src/wire.test.ts
@@ -1,0 +1,1213 @@
+import { describe, expect, it } from 'vitest';
+import type { DnsMessage, DnsQuestion, DnsRecord } from './types.js';
+import {
+  parseDnsMessage,
+  parseHeader,
+  parseName,
+  parseQuestion,
+  parseResourceRecord,
+  parseTxtValue,
+  serializeDnsMessage,
+  serializeHeader,
+  serializeName,
+  serializeQuestion,
+  serializeResourceRecord,
+  serializeTxtValue,
+} from './wire.js';
+
+describe('parseName', () => {
+  it('should parse a simple DNS name', () => {
+    const data = new Uint8Array([
+      3,
+      0x77,
+      0x77,
+      0x77, // www
+      7,
+      0x65,
+      0x78,
+      0x61,
+      0x6d,
+      0x70,
+      0x6c,
+      0x65, // example
+      3,
+      0x63,
+      0x6f,
+      0x6d, // com
+      0, // root label
+    ]);
+
+    const [name, offset] = parseName(data, 0);
+
+    expect(name).toBe('www.example.com');
+    expect(offset).toBe(17); // The next byte after the name
+  });
+
+  it('should parse name with offset', () => {
+    const data = new Uint8Array([
+      0xff,
+      0xff,
+      0xff, // garbage data
+      3,
+      0x77,
+      0x77,
+      0x77, // www
+      0, // root label
+    ]);
+
+    const [name, offset] = parseName(data, 3);
+
+    expect(name).toBe('www');
+    expect(offset).toBe(8);
+  });
+
+  it('should handle empty name', () => {
+    const data = new Uint8Array([0]); // just root label
+
+    const [name, offset] = parseName(data, 0);
+
+    expect(name).toBe('');
+    expect(offset).toBe(1);
+  });
+});
+
+describe('serializeName', () => {
+  it('should serialize a simple DNS name', () => {
+    const name = 'www.example.com';
+    const expected = new Uint8Array([
+      3,
+      0x77,
+      0x77,
+      0x77, // www
+      7,
+      0x65,
+      0x78,
+      0x61,
+      0x6d,
+      0x70,
+      0x6c,
+      0x65, // example
+      3,
+      0x63,
+      0x6f,
+      0x6d, // com
+      0, // root label
+    ]);
+
+    const result = serializeName(name);
+    expect(result).toEqual(expected);
+  });
+
+  it('should serialize single label name', () => {
+    const name = 'www';
+    const expected = new Uint8Array([
+      3,
+      0x77,
+      0x77,
+      0x77, // www
+      0, // root label
+    ]);
+
+    const result = serializeName(name);
+    expect(result).toEqual(expected);
+  });
+
+  it('should serialize empty name', () => {
+    const name = '';
+    const expected = new Uint8Array([0]); // just root label
+
+    const result = serializeName(name);
+    expect(result).toEqual(expected);
+  });
+});
+
+describe('parseQuestion', () => {
+  it('should parse a DNS question', () => {
+    const data = new Uint8Array([
+      3,
+      0x77,
+      0x77,
+      0x77, // www
+      7,
+      0x65,
+      0x78,
+      0x61,
+      0x6d,
+      0x70,
+      0x6c,
+      0x65, // example
+      3,
+      0x63,
+      0x6f,
+      0x6d, // com
+      0, // root label
+      0x00,
+      0x01, // type A
+      0x00,
+      0x01, // class IN
+    ]);
+
+    const [question, offset] = parseQuestion(data, 0);
+
+    expect(question).toEqual({
+      name: 'www.example.com',
+      type: 'A',
+      class: 'IN',
+    });
+    expect(offset).toBe(21); // name length (17) + type (2) + class (2)
+  });
+});
+
+describe('serializeQuestion', () => {
+  it('should serialize a DNS question', () => {
+    const question: DnsQuestion = {
+      name: 'www.example.com',
+      type: 'A',
+      class: 'IN',
+    };
+
+    const expected = new Uint8Array([
+      3,
+      0x77,
+      0x77,
+      0x77, // www
+      7,
+      0x65,
+      0x78,
+      0x61,
+      0x6d,
+      0x70,
+      0x6c,
+      0x65, // example
+      3,
+      0x63,
+      0x6f,
+      0x6d, // com
+      0, // root label
+      0x00,
+      0x01, // type A
+      0x00,
+      0x01, // class IN
+    ]);
+
+    const result = serializeQuestion(question);
+    expect(result).toEqual(expected);
+  });
+});
+
+describe('parseTxtValue', () => {
+  it('should parse a simple TXT value', () => {
+    const data = new Uint8Array([
+      5, // Length of first part
+      0x68,
+      0x65,
+      0x6c,
+      0x6c,
+      0x6f, // 'hello'
+    ]);
+
+    const [value, offset] = parseTxtValue(data, 0, 6);
+
+    expect(value).toBe('hello');
+    expect(offset).toBe(6);
+  });
+
+  it('should parse multiple parts', () => {
+    const data = new Uint8Array([
+      5, // Length of first part
+      0x68,
+      0x65,
+      0x6c,
+      0x6c,
+      0x6f, // 'hello'
+      5, // Length of second part
+      0x77,
+      0x6f,
+      0x72,
+      0x6c,
+      0x64, // 'world'
+    ]);
+
+    const [value, offset] = parseTxtValue(data, 0, 12);
+
+    expect(value).toBe('helloworld');
+    expect(offset).toBe(12);
+  });
+
+  it('should handle empty value', () => {
+    const data = new Uint8Array([0]); // Zero length
+
+    const [value, offset] = parseTxtValue(data, 0, 1);
+
+    expect(value).toBe('');
+    expect(offset).toBe(1);
+  });
+});
+
+describe('serializeTxtValue', () => {
+  it('should serialize a simple TXT value', () => {
+    const value = 'hello';
+    const expected = new Uint8Array([
+      5, // Length
+      0x68,
+      0x65,
+      0x6c,
+      0x6c,
+      0x6f, // 'hello'
+    ]);
+
+    const result = serializeTxtValue(value);
+    expect(result.slice(0, 6)).toEqual(expected);
+  });
+
+  it('should serialize a value that needs chunking', () => {
+    const value = 'a'.repeat(300);
+    const result = serializeTxtValue(value);
+
+    // First chunk
+    expect(result[0]).toBe(255); // First chunk length
+    expect(result.slice(1, 256)).toEqual(new Uint8Array(255).fill(0x61)); // 'a' repeated
+
+    // Second chunk
+    expect(result[256]).toBe(45); // Second chunk length (300-255=45)
+    expect(result.slice(257, 302)).toEqual(new Uint8Array(45).fill(0x61));
+  });
+
+  it('should handle empty string', () => {
+    const value = '';
+    const expected = new Uint8Array([0]); // Zero length
+
+    const result = serializeTxtValue(value);
+    expect(result.slice(0, 1)).toEqual(expected);
+  });
+});
+
+describe('parseResourceRecord', () => {
+  it('should parse an A record', () => {
+    const data = new Uint8Array([
+      3,
+      0x77,
+      0x77,
+      0x77, // www
+      0, // root label
+      0x00,
+      0x01, // type A
+      0x00,
+      0x01, // class IN
+      0x00,
+      0x00,
+      0x00,
+      0x3c, // TTL = 60
+      0x00,
+      0x04, // rdlength = 4
+      0x0a,
+      0x00,
+      0x00,
+      0x01, // IP = 10.0.0.1
+    ]);
+
+    const [record, offset] = parseResourceRecord(data, 0);
+
+    expect(record).toEqual({
+      name: 'www',
+      type: 'A',
+      class: 'IN',
+      ttl: 60,
+      ip: '10.0.0.1',
+    });
+    expect(offset).toBe(19);
+  });
+
+  it('should parse an AAAA record', () => {
+    const data = new Uint8Array([
+      3,
+      0x77,
+      0x77,
+      0x77, // www
+      0, // root label
+      0x00,
+      0x1c, // type AAAA
+      0x00,
+      0x01, // class IN
+      0x00,
+      0x00,
+      0x00,
+      0x3c, // TTL = 60
+      0x00,
+      0x10, // rdlength = 16
+      0x20,
+      0x01,
+      0x0d,
+      0xb8,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x01, // IP = 2001:db8::1
+    ]);
+
+    const [record, offset] = parseResourceRecord(data, 0);
+
+    expect(record).toEqual({
+      name: 'www',
+      type: 'AAAA',
+      class: 'IN',
+      ttl: 60,
+      ip: '2001:db8::1',
+    });
+    expect(offset).toBe(31);
+  });
+
+  it('should parse a TXT record', () => {
+    const data = new Uint8Array([
+      3,
+      0x77,
+      0x77,
+      0x77, // www
+      0, // root label
+      0x00,
+      0x10, // type TXT
+      0x00,
+      0x01, // class IN
+      0x00,
+      0x00,
+      0x00,
+      0x3c, // TTL = 60
+      0x00,
+      0x06, // rdlength = 6
+      0x05,
+      0x68,
+      0x65,
+      0x6c,
+      0x6c,
+      0x6f, // "hello"
+    ]);
+
+    const [record, offset] = parseResourceRecord(data, 0);
+
+    expect(record).toEqual({
+      name: 'www',
+      type: 'TXT',
+      class: 'IN',
+      ttl: 60,
+      value: 'hello',
+    });
+    expect(offset).toBe(21);
+  });
+
+  it('should parse a PTR record', () => {
+    const data = new Uint8Array([
+      3,
+      0x77,
+      0x77,
+      0x77, // www
+      0, // root label
+      0x00,
+      0x0c, // type PTR
+      0x00,
+      0x01, // class IN
+      0x00,
+      0x00,
+      0x00,
+      0x3c, // TTL = 60
+      0x00,
+      0x05, // rdlength = 5
+      0x04,
+      0x68,
+      0x6f,
+      0x73,
+      0x74, // "host"
+      0, // root label
+    ]);
+
+    const [record, offset] = parseResourceRecord(data, 0);
+
+    expect(record).toEqual({
+      name: 'www',
+      type: 'PTR',
+      class: 'IN',
+      ttl: 60,
+      ptr: 'host',
+    });
+    expect(offset).toBe(21);
+  });
+
+  it('should throw on unsupported record type', () => {
+    const data = new Uint8Array([
+      3,
+      0x77,
+      0x77,
+      0x77, // www
+      0, // root label
+      0x00,
+      0xff, // invalid type
+      0x00,
+      0x01, // class IN
+      0x00,
+      0x00,
+      0x00,
+      0x3c, // TTL = 60
+      0x00,
+      0x00, // rdlength = 0
+    ]);
+
+    expect(() => parseResourceRecord(data, 0)).toThrow(
+      `unsupported record type: ANY`
+    );
+  });
+});
+
+describe('serializeResourceRecord', () => {
+  it('should serialize an A record', () => {
+    const record: DnsRecord = {
+      name: 'www',
+      type: 'A',
+      class: 'IN',
+      ttl: 60,
+      ip: '10.0.0.1',
+    };
+
+    const expected = new Uint8Array([
+      3,
+      0x77,
+      0x77,
+      0x77, // www
+      0, // root label
+      0x00,
+      0x01, // type A
+      0x00,
+      0x01, // class IN
+      0x00,
+      0x00,
+      0x00,
+      0x3c, // TTL = 60
+      0x00,
+      0x04, // rdlength = 4
+      0x0a,
+      0x00,
+      0x00,
+      0x01, // IP = 10.0.0.1
+    ]);
+
+    const result = serializeResourceRecord(record);
+    expect(result).toEqual(expected);
+  });
+
+  it('should serialize an AAAA record', () => {
+    const record: DnsRecord = {
+      name: 'www',
+      type: 'AAAA',
+      class: 'IN',
+      ttl: 60,
+      ip: '2001:db8::1',
+    };
+
+    const expected = new Uint8Array([
+      3,
+      0x77,
+      0x77,
+      0x77, // www
+      0, // root label
+      0x00,
+      0x1c, // type AAAA
+      0x00,
+      0x01, // class IN
+      0x00,
+      0x00,
+      0x00,
+      0x3c, // TTL = 60
+      0x00,
+      0x10, // rdlength = 16
+      0x20,
+      0x01,
+      0x0d,
+      0xb8,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x01, // IP = 2001:db8::1
+    ]);
+
+    const result = serializeResourceRecord(record);
+    expect(result).toEqual(expected);
+  });
+
+  it('should serialize a TXT record', () => {
+    const record: DnsRecord = {
+      name: 'www',
+      type: 'TXT',
+      class: 'IN',
+      ttl: 60,
+      value: 'hello',
+    };
+
+    const expected = new Uint8Array([
+      3,
+      0x77,
+      0x77,
+      0x77, // www
+      0, // root label
+      0x00,
+      0x10, // type TXT
+      0x00,
+      0x01, // class IN
+      0x00,
+      0x00,
+      0x00,
+      0x3c, // TTL = 60
+      0x00,
+      0x06, // rdlength = 6
+      0x05,
+      0x68,
+      0x65,
+      0x6c,
+      0x6c,
+      0x6f, // "hello"
+    ]);
+
+    const result = serializeResourceRecord(record);
+    expect(result).toEqual(expected);
+  });
+
+  it('should serialize a PTR record', () => {
+    const record: DnsRecord = {
+      name: 'www',
+      type: 'PTR',
+      class: 'IN',
+      ttl: 60,
+      ptr: 'host',
+    };
+
+    const expected = new Uint8Array([
+      3,
+      0x77,
+      0x77,
+      0x77, // www
+      0, // root label
+      0x00,
+      0x0c, // type PTR
+      0x00,
+      0x01, // class IN
+      0x00,
+      0x00,
+      0x00,
+      0x3c, // TTL = 60
+      0x00,
+      0x06, // rdlength = 6
+      0x04,
+      0x68,
+      0x6f,
+      0x73,
+      0x74, // "host"
+      0, // root label
+    ]);
+
+    const result = serializeResourceRecord(record);
+    expect(result).toEqual(expected);
+  });
+
+  it('should throw on unsupported record type', () => {
+    const record: any = {
+      name: 'www',
+      type: 'MX',
+      class: 'IN',
+      ttl: 60,
+    };
+
+    expect(() => serializeResourceRecord(record)).toThrow(
+      'unsupported record type'
+    );
+  });
+});
+
+describe('parseHeader', () => {
+  it('should throw error if data is too short', () => {
+    const data = new Uint8Array(11); // Less than 12 bytes
+    expect(() => parseHeader(data)).toThrow('DNS header is too short');
+  });
+
+  it('should parse a query header', () => {
+    const data = new Uint8Array([
+      0x12,
+      0x34, // ID = 0x1234
+      0x01,
+      0x00, // Standard query, recursion desired
+      0x00,
+      0x01, // 1 question
+      0x00,
+      0x00, // 0 answers
+      0x00,
+      0x00, // 0 authority records
+      0x00,
+      0x00, // 0 additional records
+    ]);
+
+    const [header, offset] = parseHeader(data);
+
+    expect(header).toEqual({
+      id: 0x1234,
+      isResponse: false,
+      opcode: 'QUERY',
+      isAuthoritativeAnswer: false,
+      isTruncated: false,
+      isRecursionDesired: true,
+      isRecursionAvailable: false,
+      rcode: 'NOERROR',
+      questionCount: 1,
+      answerCount: 0,
+      authorityCount: 0,
+      additionalCount: 0,
+    });
+    expect(offset).toBe(12);
+  });
+
+  it('should parse a response header', () => {
+    const data = new Uint8Array([
+      0x12,
+      0x34, // ID = 0x1234
+      0x84,
+      0x80, // Response, recursion desired, recursion available
+      0x00,
+      0x01, // 1 question
+      0x00,
+      0x02, // 2 answers
+      0x00,
+      0x01, // 1 authority record
+      0x00,
+      0x03, // 3 additional records
+    ]);
+
+    const [header, offset] = parseHeader(data);
+
+    expect(header).toEqual({
+      id: 0x1234,
+      isResponse: true,
+      opcode: 'QUERY',
+      isAuthoritativeAnswer: true,
+      isTruncated: false,
+      isRecursionDesired: false,
+      isRecursionAvailable: true,
+      rcode: 'NOERROR',
+      questionCount: 1,
+      answerCount: 2,
+      authorityCount: 1,
+      additionalCount: 3,
+    });
+    expect(offset).toBe(12);
+  });
+
+  it('should parse header with uncommon flag combinations', () => {
+    const data = new Uint8Array([
+      0x12,
+      0x34, // ID = 0x1234
+      0x97, // QR=1 (response), Opcode=2 (STATUS), AA=1, TC=1, RD=1
+      0x85, // RA=1, Z=000 (reserved), RCODE=5 (REFUSED)
+      0x00,
+      0x00, // 0 questions
+      0x00,
+      0x00, // 0 answers
+      0x00,
+      0x00, // 0 authority records
+      0x00,
+      0x00, // 0 additional records
+    ]);
+
+    const [header, offset] = parseHeader(data);
+
+    expect(header).toEqual({
+      id: 0x1234,
+      isResponse: true,
+      opcode: 'STATUS',
+      isAuthoritativeAnswer: true,
+      isTruncated: true,
+      isRecursionDesired: true,
+      isRecursionAvailable: true,
+      rcode: 'REFUSED',
+      questionCount: 0,
+      answerCount: 0,
+      authorityCount: 0,
+      additionalCount: 0,
+    });
+    expect(offset).toBe(12);
+  });
+});
+
+describe('serializeHeader', () => {
+  it('should serialize a query header', () => {
+    const header = {
+      id: 0x1234,
+      isResponse: false,
+      opcode: 'QUERY' as const,
+      isAuthoritativeAnswer: false,
+      isTruncated: false,
+      isRecursionDesired: true,
+      isRecursionAvailable: false,
+      rcode: 'NOERROR' as const,
+      questionCount: 1,
+      answerCount: 0,
+      authorityCount: 0,
+      additionalCount: 0,
+    };
+
+    const expected = new Uint8Array([
+      0x12,
+      0x34, // ID = 0x1234
+      0x01,
+      0x00, // Standard query, recursion desired
+      0x00,
+      0x01, // 1 question
+      0x00,
+      0x00, // 0 answers
+      0x00,
+      0x00, // 0 authority records
+      0x00,
+      0x00, // 0 additional records
+    ]);
+
+    const result = serializeHeader(header);
+    expect(result).toEqual(expected);
+  });
+
+  it('should serialize a response header', () => {
+    const header = {
+      id: 0x1234,
+      isResponse: true,
+      opcode: 'QUERY' as const,
+      isAuthoritativeAnswer: true,
+      isTruncated: false,
+      isRecursionDesired: false,
+      isRecursionAvailable: true,
+      rcode: 'NOERROR' as const,
+      questionCount: 1,
+      answerCount: 2,
+      authorityCount: 1,
+      additionalCount: 3,
+    };
+
+    const expected = new Uint8Array([
+      0x12,
+      0x34, // ID = 0x1234
+      0x84,
+      0x80, // Response, recursion desired, recursion available
+      0x00,
+      0x01, // 1 question
+      0x00,
+      0x02, // 2 answers
+      0x00,
+      0x01, // 1 authority record
+      0x00,
+      0x03, // 3 additional records
+    ]);
+
+    const result = serializeHeader(header);
+    expect(result).toEqual(expected);
+  });
+
+  it('should serialize header with uncommon flag combinations', () => {
+    const header = {
+      id: 0x1234,
+      isResponse: true,
+      opcode: 'STATUS' as const,
+      isAuthoritativeAnswer: true,
+      isTruncated: true,
+      isRecursionDesired: true,
+      isRecursionAvailable: true,
+      rcode: 'REFUSED' as const,
+      questionCount: 0,
+      answerCount: 0,
+      authorityCount: 0,
+      additionalCount: 0,
+    };
+
+    const expected = new Uint8Array([
+      0x12,
+      0x34, // ID = 0x1234
+      0x97,
+      0x85, // Response, Status, AA=1, TC=1, RD=1, RA=1, RCODE=5
+      0x00,
+      0x00, // 0 questions
+      0x00,
+      0x00, // 0 answers
+      0x00,
+      0x00, // 0 authority records
+      0x00,
+      0x00, // 0 additional records
+    ]);
+
+    const result = serializeHeader(header);
+    expect(result).toEqual(expected);
+  });
+});
+
+describe('parseDnsMessage', () => {
+  it('should throw error if data is too short', () => {
+    const data = new Uint8Array(11); // Less than 12 bytes
+    expect(() => parseDnsMessage(data)).toThrow('DNS message is too short');
+  });
+
+  it('should parse a complete DNS message', () => {
+    const data = new Uint8Array([
+      // Header
+      0x12,
+      0x34, // ID = 0x1234
+      0x81,
+      0x80, // Response, standard query, recursion desired & available
+      0x00,
+      0x01, // 1 question
+      0x00,
+      0x01, // 1 answer
+      0x00,
+      0x01, // 1 authority
+      0x00,
+      0x01, // 1 additional
+
+      // Question section
+      0x03,
+      0x77,
+      0x77,
+      0x77, // www
+      0x07,
+      0x65,
+      0x78,
+      0x61,
+      0x6d,
+      0x70,
+      0x6c,
+      0x65, // example
+      0x03,
+      0x63,
+      0x6f,
+      0x6d, // com
+      0x00, // root label
+      0x00,
+      0x01, // type A
+      0x00,
+      0x01, // class IN
+
+      // Answer section
+      0x03,
+      0x77,
+      0x77,
+      0x77, // www
+      0x00, // root label
+      0x00,
+      0x01, // type A
+      0x00,
+      0x01, // class IN
+      0x00,
+      0x00,
+      0x00,
+      0x3c, // TTL = 60
+      0x00,
+      0x04, // rdlength = 4
+      0x0a,
+      0x00,
+      0x00,
+      0x01, // IP = 10.0.0.1
+
+      // Authority section
+      0x03,
+      0x77,
+      0x77,
+      0x77, // www
+      0x00, // root label
+      0x00,
+      0x10, // type TXT
+      0x00,
+      0x01, // class IN
+      0x00,
+      0x00,
+      0x00,
+      0x3c, // TTL = 60
+      0x00,
+      0x06, // rdlength = 6
+      0x05,
+      0x68,
+      0x65,
+      0x6c,
+      0x6c,
+      0x6f, // "hello"
+
+      // Additional section
+      0x03,
+      0x77,
+      0x77,
+      0x77, // www
+      0x00, // root label
+      0x00,
+      0x1c, // type AAAA
+      0x00,
+      0x01, // class IN
+      0x00,
+      0x00,
+      0x00,
+      0x3c, // TTL = 60
+      0x00,
+      0x10, // rdlength = 16
+      0x20,
+      0x01,
+      0x0d,
+      0xb8,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x01, // IP = 2001:db8::1
+    ]);
+
+    const message = parseDnsMessage(data);
+
+    expect(message).toEqual({
+      header: {
+        id: 0x1234,
+        isResponse: true,
+        opcode: 'QUERY',
+        isAuthoritativeAnswer: false,
+        isTruncated: false,
+        isRecursionDesired: true,
+        isRecursionAvailable: true,
+        rcode: 'NOERROR',
+        questionCount: 1,
+        answerCount: 1,
+        authorityCount: 1,
+        additionalCount: 1,
+      },
+      questions: [
+        {
+          name: 'www.example.com',
+          type: 'A',
+          class: 'IN',
+        },
+      ],
+      answers: [
+        {
+          name: 'www',
+          type: 'A',
+          class: 'IN',
+          ttl: 60,
+          ip: '10.0.0.1',
+        },
+      ],
+      authorities: [
+        {
+          name: 'www',
+          type: 'TXT',
+          class: 'IN',
+          ttl: 60,
+          value: 'hello',
+        },
+      ],
+      additionals: [
+        {
+          name: 'www',
+          type: 'AAAA',
+          class: 'IN',
+          ttl: 60,
+          ip: '2001:db8::1',
+        },
+      ],
+    });
+  });
+
+  it('should parse a message with only header and questions', () => {
+    const data = new Uint8Array([
+      // Header
+      0x12,
+      0x34, // ID = 0x1234
+      0x01,
+      0x00, // Standard query
+      0x00,
+      0x01, // 1 question
+      0x00,
+      0x00, // 0 answers
+      0x00,
+      0x00, // 0 authorities
+      0x00,
+      0x00, // 0 additionals
+
+      // Question section
+      0x03,
+      0x77,
+      0x77,
+      0x77, // www
+      0x00, // root label
+      0x00,
+      0x01, // type A
+      0x00,
+      0x01, // class IN
+    ]);
+
+    const message = parseDnsMessage(data);
+
+    expect(message).toEqual({
+      header: {
+        id: 0x1234,
+        isResponse: false,
+        opcode: 'QUERY',
+        isAuthoritativeAnswer: false,
+        isTruncated: false,
+        isRecursionDesired: true,
+        isRecursionAvailable: false,
+        rcode: 'NOERROR',
+        questionCount: 1,
+        answerCount: 0,
+        authorityCount: 0,
+        additionalCount: 0,
+      },
+      questions: [
+        {
+          name: 'www',
+          type: 'A',
+          class: 'IN',
+        },
+      ],
+      answers: [],
+      authorities: [],
+      additionals: [],
+    });
+  });
+});
+
+describe('serializeDnsMessage', () => {
+  it('should serialize a complete DNS message', () => {
+    const message: DnsMessage = {
+      header: {
+        id: 0x1234,
+        isResponse: true,
+        opcode: 'QUERY',
+        isAuthoritativeAnswer: false,
+        isTruncated: false,
+        isRecursionDesired: true,
+        isRecursionAvailable: true,
+        rcode: 'NOERROR',
+        questionCount: 0, // Will be updated automatically
+        answerCount: 0,
+        authorityCount: 0,
+        additionalCount: 0,
+      },
+      questions: [
+        {
+          name: 'www.example.com',
+          type: 'A',
+          class: 'IN',
+        },
+      ],
+      answers: [
+        {
+          name: 'www',
+          type: 'A',
+          class: 'IN',
+          ttl: 60,
+          ip: '10.0.0.1',
+        },
+      ],
+      authorities: [
+        {
+          name: 'www',
+          type: 'TXT',
+          class: 'IN',
+          ttl: 60,
+          value: 'hello',
+        },
+      ],
+      additionals: [
+        {
+          name: 'www',
+          type: 'AAAA',
+          class: 'IN',
+          ttl: 60,
+          ip: '2001:db8::1',
+        },
+      ],
+    };
+
+    const result = serializeDnsMessage(message);
+    const parsed = parseDnsMessage(result);
+
+    expect(parsed).toEqual(message);
+  });
+
+  it('should serialize a message with only header and questions', () => {
+    const message: DnsMessage = {
+      header: {
+        id: 0x1234,
+        isResponse: false,
+        opcode: 'QUERY',
+        isAuthoritativeAnswer: false,
+        isTruncated: false,
+        isRecursionDesired: true,
+        isRecursionAvailable: false,
+        rcode: 'NOERROR',
+        questionCount: 0, // Will be updated automatically
+        answerCount: 0,
+        authorityCount: 0,
+        additionalCount: 0,
+      },
+      questions: [
+        {
+          name: 'www',
+          type: 'A',
+          class: 'IN',
+        },
+      ],
+      answers: [],
+      authorities: [],
+      additionals: [],
+    };
+
+    const result = serializeDnsMessage(message);
+    const parsed = parseDnsMessage(result);
+
+    expect(parsed).toEqual(message);
+  });
+
+  it('should handle message with no sections', () => {
+    const message = {
+      header: {
+        id: 0x1234,
+        isResponse: false,
+        opcode: 'QUERY' as const,
+        isAuthoritativeAnswer: false,
+        isTruncated: false,
+        isRecursionDesired: true,
+        isRecursionAvailable: false,
+        rcode: 'NOERROR' as const,
+        questionCount: 0,
+        answerCount: 0,
+        authorityCount: 0,
+        additionalCount: 0,
+      },
+      questions: [],
+      answers: [],
+      authorities: [],
+      additionals: [],
+    };
+
+    const result = serializeDnsMessage(message);
+    const parsed = parseDnsMessage(result);
+
+    expect(parsed).toEqual(message);
+  });
+});

--- a/packages/dns/src/wire.ts
+++ b/packages/dns/src/wire.ts
@@ -1,4 +1,11 @@
-import { serializeIPv4Address, serializeIPv6Address } from '@tcpip/wire';
+import {
+  compressIPv6,
+  expandIPv6,
+  parseIPv4Address,
+  parseIPv6Address,
+  serializeIPv4Address,
+  serializeIPv6Address,
+} from '@tcpip/wire';
 import { ClassCode, OpCode, RCode, TypeCode } from './constants.js';
 import type {
   DnsClass,
@@ -10,8 +17,12 @@ import type {
   DnsRecord,
   DnsType,
 } from './types.js';
-import { chunk } from './util.js';
 
+/**
+ * Parses a DNS name.
+ *
+ * TODO: support name compression
+ */
 export function parseName(
   data: Uint8Array,
   offset: number
@@ -36,64 +47,150 @@ export function parseName(
   return [parts.join('.'), currentOffset + 1];
 }
 
+/**
+ * Serializes a DNS name.
+ *
+ * TODO: support name compression
+ */
 export function serializeName(name: string): Uint8Array {
   const parts = name.split('.');
   const bytes = new Uint8Array(name.length + 2); // +2 for length bytes
   let offset = 0;
 
-  for (const part of parts) {
-    bytes[offset] = part.length;
-    offset++;
-    for (let i = 0; i < part.length; i++) {
-      bytes[offset + i] = part.charCodeAt(i);
+  if (name !== '') {
+    for (const part of parts) {
+      bytes[offset] = part.length;
+      offset++;
+      for (let i = 0; i < part.length; i++) {
+        bytes[offset + i] = part.charCodeAt(i);
+      }
+      offset += part.length;
     }
-    offset += part.length;
   }
 
   bytes[offset] = 0; // Root label
   return bytes.slice(0, offset + 1);
 }
 
+/**
+ * Parses a DNS type.
+ */
 export function parseDnsType(type: number) {
   const [key] =
     Object.entries(TypeCode).find(([, value]) => value === type) ?? [];
+
+  if (!key) {
+    throw new Error(`unknown dns type: ${type}`);
+  }
+
   return key as DnsType;
 }
 
+/**
+ * Serializes a DNS type.
+ */
 export function serializeDnsType(type: DnsType) {
+  if (!(type in TypeCode)) {
+    throw new Error(`unknown dns type: ${type}`);
+  }
+
   return TypeCode[type];
 }
 
+/**
+ * Parses a DNS class.
+ */
 export function parseDnsClass(cls: number) {
   const [key] =
     Object.entries(ClassCode).find(([, value]) => value === cls) ?? [];
+
+  if (!key) {
+    throw new Error(`unknown dns class: ${cls}`);
+  }
+
   return key as DnsClass;
 }
 
+/**
+ * Serializes a DNS class.
+ */
 export function serializeDnsClass(cls: DnsClass) {
+  if (!(cls in ClassCode)) {
+    throw new Error(`unknown dns class: ${cls}`);
+  }
+
   return ClassCode[cls];
 }
 
+/**
+ * Parses a DNS opcode (operation code).
+ */
 export function parseDnsOpCode(opcode: number) {
   const [key] =
     Object.entries(OpCode).find(([, value]) => value === opcode) ?? [];
+
+  if (!key) {
+    throw new Error(`unknown dns opcode: ${opcode}`);
+  }
+
   return key as DnsOpCode;
 }
 
+/**
+ * Serializes a DNS opcode (operation code).
+ */
 export function serializeDnsOpCode(opcode: DnsOpCode) {
+  if (!(opcode in OpCode)) {
+    throw new Error(`unknown dns opcode: ${opcode}`);
+  }
+
   return OpCode[opcode];
 }
 
+/**
+ * Parses a DNS RCode (response code).
+ */
 export function parseDnsRCode(rcode: number) {
   const [key] =
     Object.entries(RCode).find(([, value]) => value === rcode) ?? [];
+
+  if (!key) {
+    throw new Error(`unknown dns rcode: ${rcode}`);
+  }
+
   return key as DnsRCode;
 }
 
+/**
+ * Serializes a DNS RCode (response code).
+ */
 export function serializeDnsRCode(rcode: DnsRCode) {
+  if (!(rcode in RCode)) {
+    throw new Error(`unknown dns rcode: ${rcode}`);
+  }
+
   return RCode[rcode];
 }
 
+/**
+ * Parses a DNS question section.
+ */
+export function parseQuestion(
+  data: Uint8Array,
+  offset: number
+): [question: DnsQuestion, offset: number] {
+  const [name, nameOffset] = parseName(data, offset);
+  const view = new DataView(data.buffer);
+
+  const type = parseDnsType(view.getUint16(nameOffset));
+  const cls = parseDnsClass(view.getUint16(nameOffset + 2));
+
+  return [{ name, type, class: cls }, nameOffset + 4];
+}
+
+/**
+ * Serializes a DNS question section.
+ */
 export function serializeQuestion(q: DnsQuestion) {
   const nameBytes = serializeName(q.name);
   const buffer = new Uint8Array(nameBytes.length + 4);
@@ -109,34 +206,118 @@ export function serializeQuestion(q: DnsQuestion) {
 }
 
 /**
- * Serialize a TXT record value.
+ * Parses a TXT record value.
+ */
+export function parseTxtValue(
+  data: Uint8Array,
+  offset: number,
+  length: number
+): [value: string, offset: number] {
+  const parts: string[] = [];
+  let currentOffset = offset;
+  const endOffset = offset + length;
+
+  while (currentOffset < endOffset) {
+    const partLength = data[currentOffset];
+    if (partLength === undefined) break;
+
+    currentOffset++;
+    const part = new TextDecoder().decode(
+      data.slice(currentOffset, currentOffset + partLength)
+    );
+    parts.push(part);
+    currentOffset += partLength;
+  }
+
+  return [parts.join(''), currentOffset];
+}
+
+/**
+ * Serializes a TXT record value.
+ *
+ * Splits `value` into character-strings of max 255 bytes.
  */
 export function serializeTxtValue(value: string) {
+  // For empty string, return a single zero length byte
+  if (value.length === 0) {
+    return new Uint8Array([0]);
+  }
+
   const encoder = new TextEncoder();
+  const encoded = encoder.encode(value);
 
-  // TXT records are split into chunks of 255 bytes
-  const parts = chunk(value, 255);
+  // Split into chunks of max 255 bytes
+  const parts: Uint8Array[] = [];
+  for (let i = 0; i < encoded.length; i += 255) {
+    parts.push(encoded.slice(i, Math.min(i + 255, encoded.length)));
+  }
 
-  // Each part needs a length byte followed by the text
-  const buffer = new Uint8Array(parts.length * (1 + 255));
+  // Calculate total buffer size needed: 1 length byte + actual content for each part
+  const totalSize = parts.reduce((sum, part) => sum + 1 + part.length, 0);
+  const buffer = new Uint8Array(totalSize);
 
   let offset = 0;
-
   for (const part of parts) {
     buffer[offset] = part.length;
-    buffer.set(encoder.encode(part), offset + 1);
-    offset += 1 + 255;
+    buffer.set(part, offset + 1);
+    offset += 1 + part.length;
   }
 
   return buffer;
 }
 
+/**
+ * Parses a DNS resource record (answer, authority, or additional).
+ */
+export function parseResourceRecord(
+  data: Uint8Array,
+  offset: number
+): [record: DnsRecord, offset: number] {
+  const [name, nameOffset] = parseName(data, offset);
+  const view = new DataView(data.buffer);
+
+  const type = parseDnsType(view.getUint16(nameOffset));
+  const cls = parseDnsClass(view.getUint16(nameOffset + 2));
+  const ttl = view.getUint32(nameOffset + 4);
+  const rdLength = view.getUint16(nameOffset + 8);
+
+  offset = nameOffset + 10;
+
+  switch (type) {
+    case 'A': {
+      const ip = parseIPv4Address(data.slice(offset, offset + rdLength));
+      const newOffset = offset + rdLength;
+      return [{ name, class: cls, ttl, type, ip }, newOffset];
+    }
+    case 'AAAA': {
+      const ip = parseIPv6Address(data.slice(offset, offset + rdLength));
+      const compressedIP = compressIPv6(ip);
+      const newOffset = offset + rdLength;
+      return [{ name, class: cls, ttl, type, ip: compressedIP }, newOffset];
+    }
+    case 'TXT': {
+      const [value, newOffset] = parseTxtValue(data, offset, rdLength);
+      return [{ name, class: cls, ttl, type, value }, newOffset];
+    }
+    case 'PTR': {
+      const [ptr, newOffset] = parseName(data, offset);
+      return [{ name, class: cls, ttl, type, ptr }, newOffset];
+    }
+    default: {
+      throw new Error(`unsupported record type: ${type}`);
+    }
+  }
+}
+
+/**
+ * Serializes DNS resource record data.
+ */
 export function serializeResourceData(record: DnsRecord) {
   switch (record.type) {
     case 'A':
       return serializeIPv4Address(record.ip);
     case 'AAAA':
-      return serializeIPv6Address(record.ip);
+      return serializeIPv6Address(expandIPv6(record.ip));
     case 'TXT':
       return serializeTxtValue(record.value);
     case 'PTR':
@@ -146,7 +327,10 @@ export function serializeResourceData(record: DnsRecord) {
   }
 }
 
-export function serializeAnswer(record: DnsRecord) {
+/**
+ * Serializes a DNS resource record (answer, authority, or additional).
+ */
+export function serializeResourceRecord(record: DnsRecord) {
   const HEADER_LENGTH = 10;
 
   const nameBytes = serializeName(record.name);
@@ -176,15 +360,18 @@ export function serializeAnswer(record: DnsRecord) {
   return buffer;
 }
 
-export function parseDnsMessage(data: Uint8Array): DnsMessage {
+/**
+ * Parses a DNS header.
+ */
+export function parseHeader(
+  data: Uint8Array
+): [header: DnsHeader, offset: number] {
   if (data.length < 12) {
-    throw new Error('DNS message is too short');
+    throw new Error('DNS header is too short');
   }
 
-  let offset = 0;
-
-  // Parse header
   const view = new DataView(data.buffer);
+
   const header: DnsHeader = {
     id: view.getUint16(0),
     isResponse: Boolean(data[2]! & 0x80),
@@ -199,37 +386,110 @@ export function parseDnsMessage(data: Uint8Array): DnsMessage {
     authorityCount: view.getUint16(8),
     additionalCount: view.getUint16(10),
   };
-  offset = 12;
+
+  return [header, 12]; // Header is always 12 bytes
+}
+
+/**
+ * Serializes a DNS header.
+ */
+export function serializeHeader(header: DnsHeader): Uint8Array {
+  const buffer = new Uint8Array(12);
+  const view = new DataView(buffer.buffer);
+
+  view.setUint16(0, header.id);
+
+  buffer[2] =
+    (header.isResponse ? 0x80 : 0) |
+    ((serializeDnsOpCode(header.opcode) & 0x0f) << 3) |
+    (header.isAuthoritativeAnswer ? 0x04 : 0) |
+    (header.isTruncated ? 0x02 : 0) |
+    (header.isRecursionDesired ? 0x01 : 0);
+
+  buffer[3] =
+    (header.isRecursionAvailable ? 0x80 : 0) |
+    (serializeDnsRCode(header.rcode) & 0x0f);
+
+  view.setUint16(4, header.questionCount);
+  view.setUint16(6, header.answerCount);
+  view.setUint16(8, header.authorityCount);
+  view.setUint16(10, header.additionalCount);
+
+  return buffer;
+}
+
+/**
+ * Parses a DNS message.
+ */
+export function parseDnsMessage(data: Uint8Array): DnsMessage {
+  if (data.length < 12) {
+    throw new Error('DNS message is too short');
+  }
+
+  let offset = 0;
+
+  // Parse header
+  const [header, newOffset] = parseHeader(data);
+  offset = newOffset;
 
   // Parse questions
   const questions: DnsQuestion[] = [];
   for (let i = 0; i < header.questionCount; i++) {
-    const [name, newOffset] = parseName(data, offset);
+    const [question, newOffset] = parseQuestion(data, offset);
+    questions.push(question);
     offset = newOffset;
+  }
 
-    const type = parseDnsType(view.getUint16(offset));
-    const cls = parseDnsClass(view.getUint16(offset + 2));
-    offset += 4;
+  // Parse answers
+  const answers: DnsRecord[] = [];
+  for (let i = 0; i < header.answerCount; i++) {
+    const [record, newOffset] = parseResourceRecord(data, offset);
+    answers.push(record);
+    offset = newOffset;
+  }
 
-    questions.push({ name, type, class: cls });
+  // Parse authorities
+  const authorities: DnsRecord[] = [];
+  for (let i = 0; i < header.authorityCount; i++) {
+    const [record, newOffset] = parseResourceRecord(data, offset);
+    authorities.push(record);
+    offset = newOffset;
+  }
+
+  // Parse additionals
+  const additionals: DnsRecord[] = [];
+  for (let i = 0; i < header.additionalCount; i++) {
+    const [record, newOffset] = parseResourceRecord(data, offset);
+    additionals.push(record);
+    offset = newOffset;
   }
 
   return {
     header,
     questions,
-    answers: [],
-    authorities: [],
-    additionals: [],
+    answers,
+    authorities,
+    additionals,
   };
 }
 
+/**
+ * Serializes a DNS message.
+ */
 export function serializeDnsMessage(message: DnsMessage): Uint8Array {
-  const HEADER_LENGTH = 12;
+  // Update header counts
+  message.header.questionCount = message.questions.length;
+  message.header.answerCount = message.answers?.length ?? 0;
+  message.header.authorityCount = message.authorities?.length ?? 0;
+  message.header.additionalCount = message.additionals?.length ?? 0;
 
+  const headerBytes = serializeHeader(message.header);
   const questions = message.questions.map(serializeQuestion);
-  const answers = message.answers.map(serializeAnswer);
+  const answers = message.answers?.map(serializeResourceRecord) ?? [];
+  const authorities = message.authorities?.map(serializeResourceRecord) ?? [];
+  const additionals = message.additionals?.map(serializeResourceRecord) ?? [];
 
-  let size = HEADER_LENGTH;
+  let size = headerBytes.length;
 
   // Add space for questions
   for (const question of questions) {
@@ -241,27 +501,22 @@ export function serializeDnsMessage(message: DnsMessage): Uint8Array {
     size += answer.length;
   }
 
+  // Add space for authorities
+  for (const authority of authorities) {
+    size += authority.length;
+  }
+
+  // Add space for additionals
+  for (const additional of additionals) {
+    size += additional.length;
+  }
+
   const buffer = new Uint8Array(size);
-  const view = new DataView(buffer.buffer);
   let offset = 0;
 
   // Write header
-  view.setUint16(0, message.header.id);
-  buffer[2] =
-    (message.header.isResponse ? 0x80 : 0) |
-    ((serializeDnsOpCode(message.header.opcode) & 0x0f) << 3) |
-    (message.header.isAuthoritativeAnswer ? 0x04 : 0) |
-    (message.header.isTruncated ? 0x02 : 0) |
-    (message.header.isRecursionDesired ? 0x01 : 0);
-  buffer[3] =
-    (message.header.isRecursionAvailable ? 0x80 : 0) |
-    (serializeDnsRCode(message.header.rcode) & 0x0f);
-  view.setUint16(4, message.questions.length);
-  view.setUint16(6, message.answers.length);
-  view.setUint16(8, message.authorities.length);
-  view.setUint16(10, message.additionals.length);
-
-  offset = HEADER_LENGTH;
+  buffer.set(headerBytes, offset);
+  offset += headerBytes.length;
 
   // Write questions
   for (const question of questions) {
@@ -273,6 +528,18 @@ export function serializeDnsMessage(message: DnsMessage): Uint8Array {
   for (const answer of answers) {
     buffer.set(answer, offset);
     offset += answer.length;
+  }
+
+  // Write authorities
+  for (const authority of authorities) {
+    buffer.set(authority, offset);
+    offset += authority.length;
+  }
+
+  // Write additionals
+  for (const additional of additionals) {
+    buffer.set(additional, offset);
+    offset += additional.length;
   }
 
   return buffer;


### PR DESCRIPTION
Implements a DNS client on top of tcpip.js. Completes the DNS wire implementation with a suite of tests over all core parsing/serialization functions.

Exposes DNS server and client like so:

```ts
import { createStack } from 'tcpip';
import { createDns } from '@tcpip/dns';

const stack = await createStack();
const { lookup, serve } = await createDns(stack);
```

`createDns()` is essentially a factory function that creates our `lookup()` and `serve()` functions on top of the given stack.

Then they can be used like so:
```ts
await serve({
  request: async ({ name, type }) => {
    if (name === 'example.com' && type === 'A') {
      return {
        type,
        ip: '10.0.0.1',
        ttl: 300,
      };
    }
  },
});

const ip = await lookup('example.com');
// 10.0.0.1
```

Note the DNS client defaults to `127.0.0.1:53` for its DNS queries (which `serve()` listens on by default). If you wish to point to another DNS server/port on the virtual network, you can configure it like so:

```ts
const stack = await createStack();
const { lookup } = await createDns(stack, {
  client: {
    server: '10.10.10.10',
    port: 5353,
  },
});
```
