### PR TITLE
feat: embedded dns resolution inside network stack (tcp/udp)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4404,6 +4404,7 @@
       "license": "MIT",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.3.0",
+        "@tcpip/dns": "^0.1.0",
         "@tcpip/wire": "^0.1.0"
       },
       "devDependencies": {

--- a/packages/dhcp/src/dhcp-server.ts
+++ b/packages/dhcp/src/dhcp-server.ts
@@ -5,8 +5,8 @@ import {
   DHCPMessageTypes,
 } from './constants.js';
 import type { DHCPLease, DHCPMessage, DHCPServerOptions } from './types.js';
-import { ipv4ToNumber, numberToIPv4 } from './util.js';
 import { parseDHCPMessage, serializeDHCPMessage } from './wire.js';
+import { ipv4ToNumber, numberToIPv4 } from './util.js';
 
 export async function createDHCPServer(options: DHCPServerOptions) {
   const server = new DHCPServer(options);

--- a/packages/dhcp/src/util.test.ts
+++ b/packages/dhcp/src/util.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+import { ipv4ToNumber, numberToIPv4 } from './util.js';
+
+describe('ipv4ToNumber', () => {
+  test('should convert valid IPv4 addresses to numbers', () => {
+    expect(ipv4ToNumber('0.0.0.0')).toBe(0x000000);
+    expect(ipv4ToNumber('192.168.1.1')).toBe(0xc0a80101);
+    expect(ipv4ToNumber('255.255.255.255')).toBe(0xffffffff);
+    expect(ipv4ToNumber('10.0.0.1')).toBe(0x0a000001);
+  });
+
+  test('should handle single digit octets', () => {
+    expect(ipv4ToNumber('1.2.3.4')).toBe(16909060);
+  });
+
+  test('throws error for invalid IPv4 addresses', () => {
+    expect(() => ipv4ToNumber('256.1.2.3')).toThrow();
+    expect(() => ipv4ToNumber('1.2.3.256')).toThrow();
+    expect(() => ipv4ToNumber('1.2.3')).toThrow();
+    expect(() => ipv4ToNumber('1.2.3.4.5')).toThrow();
+    expect(() => ipv4ToNumber('invalid')).toThrow();
+  });
+});
+
+describe('numberToIPv4', () => {
+  test('should convert numbers to valid IPv4 addresses', () => {
+    expect(numberToIPv4(0)).toBe('0.0.0.0');
+    expect(numberToIPv4(3232235777)).toBe('192.168.1.1');
+    expect(numberToIPv4(4294967295)).toBe('255.255.255.255');
+    expect(numberToIPv4(167772161)).toBe('10.0.0.1');
+  });
+
+  test('should handle edge cases', () => {
+    expect(numberToIPv4(16909060)).toBe('1.2.3.4');
+    expect(numberToIPv4(0xfffffffe)).toBe('255.255.255.254');
+  });
+
+  test('should throw error for invalid numbers', () => {
+    expect(() => numberToIPv4(-1)).toThrow();
+    expect(() => numberToIPv4(4294967296)).toThrow();
+    expect(() => numberToIPv4(NaN)).toThrow();
+  });
+});

--- a/packages/dhcp/src/util.ts
+++ b/packages/dhcp/src/util.ts
@@ -1,0 +1,29 @@
+import { serializeIPv4Address } from '@tcpip/wire';
+
+/**
+ * Converts an IPv4 address to a 32-bit number.
+ */
+export function ipv4ToNumber(ip: string): number {
+  const bytes = serializeIPv4Address(ip);
+  return (
+    ((bytes[0]! << 24) | (bytes[1]! << 16) | (bytes[2]! << 8) | bytes[3]!) >>> 0
+  );
+}
+
+/**
+ * Converts a 32-bit number to an IPv4 address.
+ */
+export function numberToIPv4(num: number): string {
+  if (isNaN(num) || num < 0 || num > 0xffffffff) {
+    throw new Error('invalid ipv4 number');
+  }
+
+  const bytes = new Uint8Array([
+    (num >> 24) & 0xff,
+    (num >> 16) & 0xff,
+    (num >> 8) & 0xff,
+    num & 0xff,
+  ]);
+
+  return bytes.join('.');
+}

--- a/packages/dns/src/dns-client.ts
+++ b/packages/dns/src/dns-client.ts
@@ -1,35 +1,24 @@
-import type { IPv4Address } from '@tcpip/wire';
 import type { NetworkStack } from 'tcpip';
-import type { DnsMessage, DnsQuery, DnsRecord } from './types.js';
+import type { DnsMessage, DnsQuery, DnsRecord, NameServer } from './types.js';
 import { ipToPtrName } from './util.js';
 import { parseDnsMessage, serializeDnsMessage } from './wire.js';
 
 export type DnsClientOptions = {
   /**
-   * DNS server address to query.
-   * @default 127.0.0.1
+   * Name server address to query.
+   * @default { ip: '127.0.0.1', port: 53 }
    */
-  server?: IPv4Address;
-
-  /**
-   * DNS server port.
-   * @default 53
-   */
-  port?: number;
+  nameServer?: NameServer;
 };
 
 export class DnsClient {
   #stack: NetworkStack;
-  #options: Required<DnsClientOptions>;
+  #nameServer: NameServer;
   #messageId = 0;
 
   constructor(stack: NetworkStack, options: DnsClientOptions = {}) {
     this.#stack = stack;
-    this.#options = {
-      port: 53,
-      server: '127.0.0.1',
-      ...options,
-    };
+    this.#nameServer = options.nameServer ?? { ip: '127.0.0.1', port: 53 };
   }
 
   /**
@@ -68,8 +57,8 @@ export class DnsClient {
     const writer = socket.writable.getWriter();
 
     await writer.write({
-      host: this.#options.server,
-      port: this.#options.port,
+      host: this.#nameServer.ip,
+      port: this.#nameServer.port,
       data,
     });
 

--- a/packages/dns/src/dns-server.ts
+++ b/packages/dns/src/dns-server.ts
@@ -9,6 +9,13 @@ export type RequestFn = (query: {
 
 export type DnsServerOptions = {
   /**
+   * Host to listen on.
+   *
+   * @default '0.0.0.0'
+   */
+  host?: string;
+
+  /**
    * Port to listen on.
    *
    * @default 53
@@ -32,6 +39,7 @@ export class DnsServer {
 
   async listen() {
     const socket = await this.#stack.openUdp({
+      host: this.#options.host,
       port: this.#options.port ?? 53,
     });
     this.#processDnsMessages(socket);

--- a/packages/dns/src/index.ts
+++ b/packages/dns/src/index.ts
@@ -2,9 +2,11 @@ import type { NetworkStack } from 'tcpip';
 import { DnsClient, type DnsClientOptions } from './dns-client.js';
 import { DnsServer, type DnsServerOptions } from './dns-server.js';
 
+export * from './dns-client.js';
 export * from './dns-server.js';
-export type { DnsResponse, DnsType } from './types.js';
-export { ptrNameToIP } from './util.js';
+
+export type { DnsResponse, DnsType, NameServer } from './types.js';
+export { ipToPtrName, ptrNameToIP } from './util.js';
 
 export type CreateDnsOptions = {
   /**

--- a/packages/dns/src/types.ts
+++ b/packages/dns/src/types.ts
@@ -1,5 +1,17 @@
 import type { ClassCode, TypeCode, OpCode, RCode } from './constants.js';
 
+export type NameServer = {
+  /**
+   * Name server IP address.
+   */
+  ip: string;
+
+  /**
+   * Name server port.
+   */
+  port: number;
+};
+
 export type DnsType = keyof typeof TypeCode;
 export type DnsClass = keyof typeof ClassCode;
 export type DnsOpCode = keyof typeof OpCode;

--- a/packages/tcpip/package.json
+++ b/packages/tcpip/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@bjorn3/browser_wasi_shim": "^0.3.0",
+    "@tcpip/dns": "^0.1.0",
     "@tcpip/wire": "^0.1.0"
   },
   "devDependencies": {

--- a/packages/tcpip/src/bindings/bridge-interface.ts
+++ b/packages/tcpip/src/bindings/bridge-interface.ts
@@ -57,7 +57,7 @@ export class BridgeBindings extends Bindings<BridgeImports, BridgeExports> {
       options.ports.length
     );
 
-    const bridgeInterface = new BridgeInterface();
+    const bridgeInterface = new VirtualBridgeInterface();
     this.interfaces.set(handle, bridgeInterface);
 
     return bridgeInterface;
@@ -80,4 +80,10 @@ export type BridgeInterfaceOptions = {
   ip?: IPv4Cidr;
 };
 
-export class BridgeInterface {}
+export type BridgeInterface = {
+  readonly type: 'bridge';
+};
+
+export class VirtualBridgeInterface implements BridgeInterface {
+  readonly type = 'bridge';
+}

--- a/packages/tcpip/src/bindings/loopback-interface.ts
+++ b/packages/tcpip/src/bindings/loopback-interface.ts
@@ -24,7 +24,7 @@ export class LoopbackBindings extends Bindings<
 
   imports = {
     register_loopback_interface: (handle: LoopbackInterfaceHandle) => {
-      const loopbackInterface = new LoopbackInterface();
+      const loopbackInterface = new VirtualLoopbackInterface();
       this.interfaces.set(handle, loopbackInterface);
     },
   };
@@ -65,4 +65,11 @@ export class LoopbackBindings extends Bindings<
 export type LoopbackInterfaceOptions = {
   ip?: IPv4Cidr;
 };
-export class LoopbackInterface {}
+
+export type LoopbackInterface = {
+  readonly type: 'loopback';
+};
+
+export class VirtualLoopbackInterface implements LoopbackInterface {
+  readonly type = 'loopback';
+}

--- a/packages/tcpip/src/bindings/tap-interface.ts
+++ b/packages/tcpip/src/bindings/tap-interface.ts
@@ -62,7 +62,7 @@ export class TapBindings extends Bindings<TapImports, TapExports> {
 
   imports = {
     register_tap_interface: (handle: TapInterfaceHandle) => {
-      const tapInterface = new TapInterface();
+      const tapInterface = new VirtualTapInterface();
 
       tapInterfaceHooks.setOuter(tapInterface, {
         handle,
@@ -150,10 +150,19 @@ export type TapInterfaceOptions = {
   ip?: IPv4Cidr;
 };
 
-export class TapInterface {
+export type TapInterface = {
+  readonly type: 'tap';
+  readable: ReadableStream<Uint8Array>;
+  writable: WritableStream<Uint8Array>;
+  listen(): AsyncIterableIterator<Uint8Array>;
+  [Symbol.asyncIterator](): AsyncIterableIterator<Uint8Array>;
+};
+
+export class VirtualTapInterface implements TapInterface {
   #readableController?: ReadableStreamController<Uint8Array>;
   #isListening = false;
 
+  readonly type = 'tap' as const;
   readable: ReadableStream<Uint8Array>;
   writable: WritableStream<Uint8Array>;
 

--- a/packages/tcpip/src/bindings/tcp.ts
+++ b/packages/tcpip/src/bindings/tcp.ts
@@ -225,7 +225,7 @@ export class TcpBindings extends Bindings<TcpImports, TcpExports> {
 
   async listen(options: TcpListenerOptions) {
     using hostPtr = options.host
-      ? this.copyToMemory(serializeIPv4Address(options.host))
+      ? this.copyToMemory(await this.#resolveHost(options.host))
       : null;
 
     const handle = this.exports.create_tcp_listener(hostPtr, options.port);
@@ -255,7 +255,7 @@ export class TcpBindings extends Bindings<TcpImports, TcpExports> {
 }
 
 export type TcpListenerOptions = {
-  host?: IPv4Address;
+  host?: string;
   port: number;
 };
 

--- a/packages/tcpip/src/bindings/tcp.ts
+++ b/packages/tcpip/src/bindings/tcp.ts
@@ -1,3 +1,4 @@
+import type { DnsClient } from '@tcpip/dns';
 import { serializeIPv4Address, type IPv4Address } from '@tcpip/wire';
 import { LwipError } from '../lwip/errors.js';
 import type { Pointer } from '../types.js';
@@ -72,6 +73,21 @@ export class TcpBindings extends Bindings<TcpImports, TcpExports> {
   #tcpListeners = new Map<TcpListenerHandle, TcpListener>();
   #tcpConnections = new EventMap<TcpConnectionHandle, TcpConnection>();
   #tcpAcks = new Map<TcpConnectionHandle, (length: number) => void>();
+  #dnsClient: DnsClient;
+
+  async #resolveHost(host: string) {
+    try {
+      return serializeIPv4Address(host);
+    } catch (e) {
+      const ip = await this.#dnsClient.lookup(host);
+      return serializeIPv4Address(ip);
+    }
+  }
+
+  constructor(dnsClient: DnsClient) {
+    super();
+    this.#dnsClient = dnsClient;
+  }
 
   imports = {
     accept_tcp_connection: async (
@@ -88,7 +104,7 @@ export class TcpBindings extends Bindings<TcpImports, TcpExports> {
       // Wait for synchronous lwIP operations to complete to prevent reentrancy issues
       await nextMicrotask();
 
-      const connection = new TcpConnection();
+      const connection = new VirtualTcpConnection();
 
       tcpConnectionHooks.setOuter(connection, {
         send: async (data) => {
@@ -135,7 +151,7 @@ export class TcpBindings extends Bindings<TcpImports, TcpExports> {
       // Wait for synchronous lwIP operations to complete to prevent reentrancy issues
       await nextMicrotask();
 
-      const connection = new TcpConnection();
+      const connection = new VirtualTcpConnection();
 
       tcpConnectionHooks.setOuter(connection, {
         send: async (data) => {
@@ -214,7 +230,7 @@ export class TcpBindings extends Bindings<TcpImports, TcpExports> {
 
     const handle = this.exports.create_tcp_listener(hostPtr, options.port);
 
-    const tcpListener = new TcpListener();
+    const tcpListener = new VirtualTcpListener();
 
     tcpListenerHooks.setOuter(tcpListener, {});
 
@@ -224,7 +240,7 @@ export class TcpBindings extends Bindings<TcpImports, TcpExports> {
   }
 
   async connect(options: TcpConnectionOptions) {
-    using hostPtr = this.copyToMemory(serializeIPv4Address(options.host));
+    using hostPtr = this.copyToMemory(await this.#resolveHost(options.host));
 
     const handle = this.exports.create_tcp_connection(hostPtr, options.port);
 
@@ -243,7 +259,13 @@ export type TcpListenerOptions = {
   port: number;
 };
 
-export class TcpListener implements AsyncIterable<TcpConnection> {
+export type TcpListener = {
+  [Symbol.asyncIterator](): AsyncIterableIterator<TcpConnection>;
+};
+
+export class VirtualTcpListener
+  implements TcpListener, AsyncIterable<TcpConnection>
+{
   #connections: TcpConnection[] = [];
   #notifyConnection?: () => void;
 
@@ -269,11 +291,20 @@ export class TcpListener implements AsyncIterable<TcpConnection> {
 }
 
 export type TcpConnectionOptions = {
-  host: IPv4Address;
+  host: string;
   port: number;
 };
 
-export class TcpConnection implements AsyncIterable<Uint8Array> {
+export type TcpConnection = {
+  readable: ReadableStream<Uint8Array>;
+  writable: WritableStream<Uint8Array>;
+  close(): Promise<void>;
+  [Symbol.asyncIterator](): AsyncIterator<Uint8Array>;
+};
+
+export class VirtualTcpConnection
+  implements TcpConnection, AsyncIterable<Uint8Array>
+{
   #receiveBuffer: Uint8Array[] = [];
   #readableController?: ReadableStreamDefaultController<Uint8Array>;
   #writableController?: WritableStreamDefaultController;

--- a/packages/tcpip/src/bindings/tun-interface.ts
+++ b/packages/tcpip/src/bindings/tun-interface.ts
@@ -51,7 +51,7 @@ export class TunBindings extends Bindings<TunImports, TunExports> {
 
   imports = {
     register_tun_interface: (handle: TunInterfaceHandle) => {
-      const tunInterface = new TunInterface();
+      const tunInterface = new VirtualTunInterface();
 
       tunInterfaceHooks.setOuter(tunInterface, {
         sendPacket: (packet) => {
@@ -123,10 +123,19 @@ export type TunInterfaceOptions = {
   ip?: IPv4Cidr;
 };
 
-export class TunInterface {
+export type TunInterface = {
+  readonly type: 'tun';
+  readable: ReadableStream<Uint8Array>;
+  writable: WritableStream<Uint8Array>;
+  listen(): AsyncIterableIterator<Uint8Array>;
+  [Symbol.asyncIterator](): AsyncIterableIterator<Uint8Array>;
+};
+
+export class VirtualTunInterface implements TunInterface {
   #readableController?: ReadableStreamController<Uint8Array>;
   #isListening = false;
 
+  readonly type = 'tun' as const;
   readable: ReadableStream<Uint8Array>;
   writable: WritableStream<Uint8Array>;
 

--- a/packages/tcpip/src/bindings/udp.ts
+++ b/packages/tcpip/src/bindings/udp.ts
@@ -107,6 +107,10 @@ export class UdpBindings extends Bindings<UdpImports, UdpExports> {
 
     const handle = this.exports.open_udp_socket(hostPtr, options.port ?? 0);
 
+    if (Number(handle) === 0) {
+      throw new Error('failed to open udp socket');
+    }
+
     const udpSocket = new VirtualUdpSocket();
 
     udpSocketHooks.setOuter(udpSocket, {
@@ -146,7 +150,7 @@ export type UdpSocketOptions = {
    *
    * If not provided, the socket will bind to all available interfaces.
    */
-  host?: IPv4Address;
+  host?: string;
 
   /**
    * The local port to bind to.

--- a/packages/tcpip/src/bindings/udp.ts
+++ b/packages/tcpip/src/bindings/udp.ts
@@ -1,3 +1,4 @@
+import type { DnsClient } from '@tcpip/dns';
 import {
   type IPv4Address,
   parseIPv4Address,
@@ -9,7 +10,7 @@ import { EventMap, fromReadable, Hooks, nextMicrotask } from '../util.js';
 import { Bindings } from './base.js';
 
 export type UdpDatagram = {
-  host: IPv4Address;
+  host: string;
   port: number;
   data: Uint8Array;
 };
@@ -25,7 +26,7 @@ type UdpSocketInnerHooks = {
   receive(datagram: UdpDatagram): Promise<void>;
 };
 
-const UdpSocketHooks = new Hooks<
+const udpSocketHooks = new Hooks<
   UdpSocket,
   UdpSocketOuterHooks,
   UdpSocketInnerHooks
@@ -54,7 +55,22 @@ export type UdpExports = {
 };
 
 export class UdpBindings extends Bindings<UdpImports, UdpExports> {
-  #UdpSockets = new EventMap<UdpSocketHandle, UdpSocket>();
+  #udpSockets = new EventMap<UdpSocketHandle, UdpSocket>();
+  #dnsClient: DnsClient;
+
+  async #resolveHost(host: string) {
+    try {
+      return serializeIPv4Address(host);
+    } catch (e) {
+      const ip = await this.#dnsClient.lookup(host);
+      return serializeIPv4Address(ip);
+    }
+  }
+
+  constructor(dnsClient: DnsClient) {
+    super();
+    this.#dnsClient = dnsClient;
+  }
 
   imports = {
     receive_udp_datagram: async (
@@ -66,7 +82,7 @@ export class UdpBindings extends Bindings<UdpImports, UdpExports> {
     ) => {
       const host = this.copyFromMemory(hostPtr, 4);
       const datagram = this.copyFromMemory(datagramPtr, length);
-      const socket = this.#UdpSockets.get(handle);
+      const socket = this.#udpSockets.get(handle);
 
       if (!socket) {
         console.error('received datagram on unknown udp socket');
@@ -76,7 +92,7 @@ export class UdpBindings extends Bindings<UdpImports, UdpExports> {
       // Wait for synchronous lwIP operations to complete to prevent reentrancy issues
       await nextMicrotask();
 
-      UdpSocketHooks.getInner(socket).receive({
+      udpSocketHooks.getInner(socket).receive({
         host: parseIPv4Address(host),
         port,
         data: datagram,
@@ -86,16 +102,18 @@ export class UdpBindings extends Bindings<UdpImports, UdpExports> {
 
   async open(options: UdpSocketOptions) {
     using hostPtr = options.host
-      ? this.copyToMemory(serializeIPv4Address(options.host))
+      ? this.copyToMemory(await this.#resolveHost(options.host))
       : null;
 
     const handle = this.exports.open_udp_socket(hostPtr, options.port ?? 0);
 
-    const udpSocket = new UdpSocket();
+    const udpSocket = new VirtualUdpSocket();
 
-    UdpSocketHooks.setOuter(udpSocket, {
+    udpSocketHooks.setOuter(udpSocket, {
       send: async (datagram: UdpDatagram) => {
-        using hostPtr = this.copyToMemory(serializeIPv4Address(datagram.host));
+        using hostPtr = this.copyToMemory(
+          await this.#resolveHost(datagram.host)
+        );
         using datagramPtr = this.copyToMemory(datagram.data);
 
         const result = this.exports.send_udp_datagram(
@@ -112,11 +130,11 @@ export class UdpBindings extends Bindings<UdpImports, UdpExports> {
       },
       close: async () => {
         this.exports.close_udp_socket(handle);
-        this.#UdpSockets.delete(handle);
+        this.#udpSockets.delete(handle);
       },
     });
 
-    this.#UdpSockets.set(handle, udpSocket);
+    this.#udpSockets.set(handle, udpSocket);
 
     return udpSocket;
   }
@@ -138,7 +156,14 @@ export type UdpSocketOptions = {
   port?: number;
 };
 
-export class UdpSocket implements AsyncIterable<UdpDatagram> {
+export type UdpSocket = {
+  readable: ReadableStream<UdpDatagram>;
+  writable: WritableStream<UdpDatagram>;
+  close(): Promise<void>;
+  [Symbol.asyncIterator](): AsyncIterator<UdpDatagram>;
+};
+
+export class VirtualUdpSocket implements UdpSocket, AsyncIterable<UdpDatagram> {
   #readableController?: ReadableStreamDefaultController<UdpDatagram>;
   #writableController?: WritableStreamDefaultController;
 
@@ -146,7 +171,7 @@ export class UdpSocket implements AsyncIterable<UdpDatagram> {
   writable: WritableStream<UdpDatagram>;
 
   constructor() {
-    UdpSocketHooks.setInner(this, {
+    udpSocketHooks.setInner(this, {
       receive: async (datagram: UdpDatagram) => {
         if (!this.#readableController) {
           throw new Error('readable controller not initialized');
@@ -166,13 +191,13 @@ export class UdpSocket implements AsyncIterable<UdpDatagram> {
         this.#writableController = controller;
       },
       write: async (datagram) => {
-        await UdpSocketHooks.getOuter(this).send(datagram);
+        await udpSocketHooks.getOuter(this).send(datagram);
       },
     });
   }
 
   async close() {
-    await UdpSocketHooks.getOuter(this).close();
+    await udpSocketHooks.getOuter(this).close();
     this.#readableController?.error(new Error('udp socket closed'));
     this.#writableController?.error(new Error('udp socket closed'));
   }

--- a/packages/tcpip/src/index.ts
+++ b/packages/tcpip/src/index.ts
@@ -1,25 +1,31 @@
 export { createStack, type NetworkStack } from './stack.js';
 export type { NetworkInterface } from './types.js';
 
-export { type LoopbackInterfaceOptions } from './bindings/loopback-interface.js';
-export type { LoopbackInterface } from './bindings/loopback-interface.js';
+export type {
+  LoopbackInterface,
+  LoopbackInterfaceOptions,
+} from './bindings/loopback-interface.js';
 
-export { type TunInterfaceOptions } from './bindings/tun-interface.js';
-export type { TunInterface } from './bindings/tun-interface.js';
+export type {
+  TunInterface,
+  TunInterfaceOptions,
+} from './bindings/tun-interface.js';
 
-export {
-  VirtualTapInterface as TapInterface,
-  type TapInterfaceOptions,
+export type {
+  TapInterface,
+  TapInterfaceOptions,
 } from './bindings/tap-interface.js';
 
-export { type BridgeInterfaceOptions } from './bindings/bridge-interface.js';
-export type { BridgeInterface } from './bindings/bridge-interface.js';
+export type {
+  BridgeInterface,
+  BridgeInterfaceOptions,
+} from './bindings/bridge-interface.js';
 
-export {
-  type TcpConnectionOptions,
-  type TcpListenerOptions,
+export type {
+  TcpConnectionOptions,
+  TcpListenerOptions,
 } from './bindings/tcp.js';
 export type { TcpConnection, TcpListener } from './bindings/tcp.js';
 
-export { type UdpDatagram, type UdpSocketOptions } from './bindings/udp.js';
+export type { UdpDatagram, UdpSocketOptions } from './bindings/udp.js';
 export type { UdpSocket } from './bindings/udp.js';

--- a/packages/tcpip/src/index.ts
+++ b/packages/tcpip/src/index.ts
@@ -1,35 +1,25 @@
-export { createStack, NetworkStack } from './stack.js';
+export { createStack, type NetworkStack } from './stack.js';
 export type { NetworkInterface } from './types.js';
 
-export {
-  LoopbackInterface,
-  type LoopbackInterfaceOptions,
-} from './bindings/loopback-interface.js';
+export { type LoopbackInterfaceOptions } from './bindings/loopback-interface.js';
+export type { LoopbackInterface } from './bindings/loopback-interface.js';
+
+export { type TunInterfaceOptions } from './bindings/tun-interface.js';
+export type { TunInterface } from './bindings/tun-interface.js';
 
 export {
-  TunInterface,
-  type TunInterfaceOptions,
-} from './bindings/tun-interface.js';
-
-export {
-  TapInterface,
+  VirtualTapInterface as TapInterface,
   type TapInterfaceOptions,
 } from './bindings/tap-interface.js';
 
-export {
-  BridgeInterface,
-  type BridgeInterfaceOptions,
-} from './bindings/bridge-interface.js';
+export { type BridgeInterfaceOptions } from './bindings/bridge-interface.js';
+export type { BridgeInterface } from './bindings/bridge-interface.js';
 
 export {
-  TcpConnection,
-  TcpListener,
   type TcpConnectionOptions,
   type TcpListenerOptions,
 } from './bindings/tcp.js';
+export type { TcpConnection, TcpListener } from './bindings/tcp.js';
 
-export {
-  UdpSocket,
-  type UdpDatagram,
-  type UdpSocketOptions,
-} from './bindings/udp.js';
+export { type UdpDatagram, type UdpSocketOptions } from './bindings/udp.js';
+export type { UdpSocket } from './bindings/udp.js';

--- a/packages/tcpip/src/stack.test.ts
+++ b/packages/tcpip/src/stack.test.ts
@@ -808,7 +808,7 @@ describe('udp', () => {
 });
 
 describe('dns', () => {
-  test('can resolve a hostname via udp', async () => {
+  test('can resolve a hostname during udp bind and send', async () => {
     const stack = await createStack();
     const { serve } = await createDns(stack);
 
@@ -824,7 +824,7 @@ describe('dns', () => {
       },
     });
 
-    const socket1 = await stack.openUdp({ port: 8080 });
+    const socket1 = await stack.openUdp({ host: 'example.com', port: 8080 });
     const socket2 = await stack.openUdp({ port: 8081 });
 
     const reader = socket1.readable.getReader();
@@ -844,7 +844,7 @@ describe('dns', () => {
     expect(received.value.data).toStrictEqual(data);
   });
 
-  test('can resolve a hostname via tcp', async () => {
+  test('can resolve a hostname during tcp bind and connection', async () => {
     const stack = await createStack();
     const { serve } = await createDns(stack);
 
@@ -861,6 +861,7 @@ describe('dns', () => {
     });
 
     const listener = await stack.listenTcp({
+      host: 'example.com',
       port: 8080,
     });
 

--- a/packages/tcpip/src/types.ts
+++ b/packages/tcpip/src/types.ts
@@ -1,4 +1,7 @@
-import type { BridgeExports } from './bindings/bridge-interface.js';
+import type {
+  BridgeExports,
+  BridgeInterface,
+} from './bindings/bridge-interface.js';
 import type {
   LoopbackExports,
   LoopbackInterface,
@@ -40,4 +43,8 @@ export type WasmInstance = {
   exports: WasmExports;
 };
 
-export type NetworkInterface = LoopbackInterface | TunInterface | TapInterface;
+export type NetworkInterface =
+  | LoopbackInterface
+  | TunInterface
+  | TapInterface
+  | BridgeInterface;

--- a/packages/tcpip/wasm/include/lwipopts.h
+++ b/packages/tcpip/wasm/include/lwipopts.h
@@ -51,10 +51,13 @@
 #define TCP_WND (4 * TCP_MSS)                         // TCP window size
 #define TCP_SND_BUF (4 * TCP_MSS)                     // TCP send buffer size
 #define TCP_SND_QUEUELEN (2 * TCP_SND_BUF / TCP_MSS)  // TCP send queue length
+#define MEMP_NUM_TCP_PCB 256                          // Number of simultaneously active TCP PCBs
+#define MEMP_NUM_TCP_PCB_LISTEN 256                   // Number of simultaneously active listening TCP PCBs
 
 // UDP options
 #define LWIP_UDP 1                             // Enable UDP functionality
 #define LWIP_IP_ACCEPT_UDP_PORT(dst_port) (1)  // Allow broadcast IP packets on all UDP ports
+#define MEMP_NUM_UDP_PCB 256                   // Number of simultaneously active UDP PCBs
 
 // Checksum options (packet integrity)
 #define CHECKSUM_GEN_IP 1      // Generate checksums for IP packets

--- a/packages/wire/src/ipv4.test.ts
+++ b/packages/wire/src/ipv4.test.ts
@@ -24,6 +24,13 @@ test('parses an IPv4 address string into a Uint8Array', () => {
   );
 });
 
+test('throws an error for invalid IPv4 address strings', () => {
+  expect(() => serializeIPv4Address('192.168.1')).toThrow();
+  expect(() => serializeIPv4Address('192.168.1.')).toThrow();
+  expect(() => serializeIPv4Address('192.168.1.256')).toThrow();
+  expect(() => serializeIPv4Address('hello')).toThrow();
+});
+
 test('parses a cidr notation string', () => {
   expect(serializeIPv4Cidr('192.168.1.1/24')).toEqual({
     ipAddress: Uint8Array.from([192, 168, 1, 1]),
@@ -41,7 +48,7 @@ test('throws an error for invalid mask sizes', () => {
   expect(() => generateNetmask(33)).toThrow();
 });
 
-test('formats a Uint8Array into an IPv4 address string', () => {
+test('parses a Uint8Array into an IPv4 address string', () => {
   expect(parseIPv4Address(Uint8Array.from([192, 168, 1, 1]))).toBe(
     '192.168.1.1'
   );
@@ -50,6 +57,13 @@ test('formats a Uint8Array into an IPv4 address string', () => {
     '255.255.255.255'
   );
   expect(parseIPv4Address(Uint8Array.from([0, 0, 0, 0]))).toBe('0.0.0.0');
+});
+
+test('throws an error for invalid IPv4 address Uint8Arrays', () => {
+  expect(() => parseIPv4Address(Uint8Array.from([192, 168, 1]))).toThrow();
+  expect(
+    () => parseIPv4Address(Uint8Array.from([104, 101, 108, 108, 111])) // 'hello'
+  ).toThrow();
 });
 
 test('parses an IPv4 packet containing a UDP datagram', () => {

--- a/packages/wire/src/ipv6.test.ts
+++ b/packages/wire/src/ipv6.test.ts
@@ -52,6 +52,29 @@ describe('serializeIPv6Address', () => {
     const serialized = serializeIPv6Address(ip);
     expect(serialized).toEqual(new Uint8Array(16).fill(255));
   });
+
+  test('serializes a compressed IPv6 address', () => {
+    const ip = '2001:db8::1';
+    const serialized = serializeIPv6Address(ip);
+    expect(serialized).toEqual(
+      new Uint8Array([
+        0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x01,
+      ])
+    );
+  });
+
+  test('throws an error for invalid IPv6 address strings', () => {
+    expect(() =>
+      serializeIPv6Address('2001:0db8:0000:0000:0000:0000:0000')
+    ).toThrow();
+    expect(() =>
+      serializeIPv6Address('2001:0db8:0000:0000:0000:0000:0000:0001:0001')
+    ).toThrow();
+    expect(() =>
+      serializeIPv6Address('2001:0db8:0000:0000:0000:0000:0000:000g')
+    ).toThrow();
+  });
 });
 
 describe('compressIPv6', () => {

--- a/packages/wire/src/util.test.ts
+++ b/packages/wire/src/util.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { calculateChecksum } from './util.js';
+import { calculateChecksum, parseHex, parseUint } from './util.js';
 
 describe('calculateChecksum', () => {
   test('returns the correct checksum for an empty array', () => {
@@ -30,5 +30,57 @@ describe('calculateChecksum', () => {
     const data = new Uint8Array([0x01, 0x02, 0x03]);
     const checksum = calculateChecksum(data);
     expect(checksum).toBe(0xfbfd);
+  });
+});
+
+describe('parseUint', () => {
+  test('should parse valid integers correctly', () => {
+    expect(parseUint('0')).toBe(0);
+    expect(parseUint('1')).toBe(1);
+    expect(parseUint('123')).toBe(123);
+    expect(parseUint('999')).toBe(999);
+  });
+
+  test('should throw error for empty string', () => {
+    expect(() => parseUint('')).toThrow('empty string');
+  });
+
+  test('should throw error for invalid characters', () => {
+    expect(() => parseUint('12a')).toThrow('invalid character');
+    expect(() => parseUint('1.2')).toThrow('invalid character');
+    expect(() => parseUint('-123')).toThrow('invalid character');
+    expect(() => parseUint(' 123')).toThrow('invalid character');
+    expect(() => parseUint('123 ')).toThrow('invalid character');
+  });
+});
+
+describe('parseHex', () => {
+  test('should parse lowercase hex digits correctly', () => {
+    expect(parseHex('ab')).toBe(171);
+    expect(parseHex('ff')).toBe(255);
+    expect(parseHex('dead')).toBe(57005);
+  });
+
+  test('should parse uppercase hex digits correctly', () => {
+    expect(parseHex('AB')).toBe(171);
+    expect(parseHex('FF')).toBe(255);
+    expect(parseHex('DEAD')).toBe(57005);
+  });
+
+  test('should parse mixed case hex digits correctly', () => {
+    expect(parseHex('aB')).toBe(171);
+    expect(parseHex('DeAd')).toBe(57005);
+  });
+
+  test('should parse numeric hex digits correctly', () => {
+    expect(parseHex('12')).toBe(18);
+    expect(parseHex('90')).toBe(144);
+  });
+
+  test('should throw error for invalid hex characters', () => {
+    expect(() => parseHex('g')).toThrow('invalid hex character');
+    expect(() => parseHex('xyz')).toThrow('invalid hex character');
+    expect(() => parseHex('12.34')).toThrow('invalid hex character');
+    expect(() => parseHex('')).not.toThrow();
   });
 });

--- a/packages/wire/src/util.ts
+++ b/packages/wire/src/util.ts
@@ -28,3 +28,70 @@ export function calculateChecksum(
   // Return the one's complement of the sum
   return ~sum & 0xffff;
 }
+
+/**
+ * Parses a string into an unsigned integer.
+ *
+ * Uses direct character code comparison instead of `parseInt`
+ * for better performance and stricter validation.
+ *
+ * `parseInt` is too permissive and allows invalid input like
+ * whitespace, signs, and decimals.
+ *
+ * Throws if invalid characters are encountered.
+ */
+export function parseUint(str: string): number {
+  if (str.length === 0) {
+    throw new Error('empty string');
+  }
+
+  let value = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+
+    if (char < 48 || char > 57) {
+      // 0-9
+      throw new Error('invalid character');
+    }
+
+    value = value * 10 + (char - 48);
+  }
+
+  return value;
+}
+
+/**
+ * Parses a hex string into a number.
+ *
+ * Uses direct character code comparison instead of `parseInt`
+ * for better performance and stricter validation.
+ *
+ * `parseInt` is too permissive and allows invalid hex characters
+ * to slip through.
+ *
+ * Throws if invalid hex characters are encountered.
+ */
+export function parseHex(hex: string): number {
+  let value = 0;
+  for (let i = 0; i < hex.length; i++) {
+    const char = hex.charCodeAt(i);
+    let digit: number;
+
+    if (char >= 48 && char <= 57) {
+      // 0-9
+      digit = char - 48;
+    } else if (char >= 97 && char <= 102) {
+      // a-f
+      digit = char - 87;
+    } else if (char >= 65 && char <= 70) {
+      // A-F
+      digit = char - 55;
+    } else {
+      throw new Error('invalid hex character');
+    }
+
+    value = (value << 4) | digit;
+  }
+
+  return value;
+}


### PR DESCRIPTION
Adds DNS resolution to the TCP and UDP APIs. This means you can now pass a hostname to either API and the stack will attempt to resolve its IP automatically before binding or connecting.

The default name server for the stack is the loopback IP `127.0.0.1` on port 53. This makes it simple to spin up your own DNS server on the same stack and resolve IPs locally:

```ts
import { createStack } from 'tcpip';
import { createDns } from '@tcpip/dns';

const stack = await createStack();
const { serve } = await createDns(stack);

// Serve DNS queries
await serve({
  request: async ({ name, type }) => {
    if (name === 'example.com' && type === 'A') {
      return {
        type,
        ip: '127.0.0.1',
        ttl: 300,
      };
    }
  },
});

// ... TCP or UDP connection, see below
```

If you wish to point the stack's name server to another DNS server on your virtual network, you can do so by passing the `nameServer` option to `createStack()`:

```ts
const stack = await createStack({
  nameServer: { ip: '10.0.0.1', port: 5353 },
});
```

Below are examples on how this works with the TCP and UDP APIs:
#### TCP
```ts
const stack = await createStack();
const { serve } = await createDns(stack);

await serve({
  request: async ({ name, type }) => {
    if (name === 'example.com' && type === 'A') {
      return {
        type,
        ip: '127.0.0.1',
        ttl: 300,
      };
    }
  },
});

const listener = await stack.listenTcp({
  port: 8080,
});

// `host` can now be a hostname
await stack.connectTcp({
  host: 'example.com',
  port: 8080,
});

// ...
```

#### UDP
```ts
const stack = await createStack();
const { serve } = await createDns(stack);

await serve({
  request: async ({ name, type }) => {
    if (name === 'example.com' && type === 'A') {
      return {
        type,
        ip: '127.0.0.1',
        ttl: 300,
      };
    }
  },
});

const socket1 = await stack.openUdp({ port: 8080 });
const socket2 = await stack.openUdp({ port: 8081 });

const reader = socket1.readable.getReader();
const writer = socket2.writable.getWriter();

const data = new Uint8Array([0x01, 0x02, 0x03, 0x04]);

// `host` can now be a hostname
await writer.write({ host: 'example.com', port: 8080, data: data });
const received = await reader.read();
```