### PR TITLE
Fixes UDP broadcast on multiple interfaces

### DIFF
--- a/packages/tcpip/wasm/udp.c
+++ b/packages/tcpip/wasm/udp.c
@@ -11,38 +11,41 @@ extern void receive_udp_datagram(struct udp_pcb *socket, const uint8_t *addr, ui
 
 EXPORT("send_udp_datagram")
 err_t send_udp_datagram(struct udp_pcb *socket, const uint8_t *addr, uint16_t port, uint8_t *datagram, uint16_t length) {
-  struct pbuf *p = pbuf_alloc(PBUF_TRANSPORT, length, PBUF_RAM);
-  if (p == NULL) {
-    return ERR_MEM;
-  }
-  pbuf_take(p, datagram, length);
-
   ip4_addr_t ipaddr;
   IP4_ADDR(&ipaddr, addr[0], addr[1], addr[2], addr[3]);
 
   err_t code = ERR_OK;
 
   // If the destination IP is the limited broadcast address (255.255.255.255),
-  // send on all interfaces that are up and have the broadcast flag set
+  // send on all interfaces that are up, support ARP, and have the broadcast flag set
   if (ipaddr.addr == PP_HTONL(IPADDR_BROADCAST)) {
     struct netif *netif;
+
     NETIF_FOREACH(netif) {
-      if (netif_is_up(netif) && netif_is_flag_set(netif, NETIF_FLAG_BROADCAST)) {
-        code = udp_sendto_if(socket, p, IP_ADDR_BROADCAST, port, netif);
-        if (code != ERR_OK) {
-          pbuf_free(p);
-          return code;
+      if (netif_is_up(netif) && netif_is_flag_set(netif, NETIF_FLAG_ETHARP) && netif_is_flag_set(netif, NETIF_FLAG_BROADCAST)) {
+        struct pbuf *p = pbuf_alloc(PBUF_TRANSPORT, length, PBUF_RAM);
+        if (p == NULL) {
+          return ERR_MEM;
         }
+        pbuf_take(p, datagram, length);
+        err_t err = udp_sendto_if(socket, p, IP_ADDR_BROADCAST, port, netif);
+        pbuf_free(p);
       }
     }
+
+    return ERR_OK;
   }
   // Otherwise, send to the specified IP address using lwIP's automatic routing
   else {
+    struct pbuf *p = pbuf_alloc(PBUF_TRANSPORT, length, PBUF_RAM);
+    if (p == NULL) {
+      return ERR_MEM;
+    }
+    pbuf_take(p, datagram, length);
     code = udp_sendto(socket, p, &ipaddr, port);
+    pbuf_free(p);
+    return code;
   }
-
-  pbuf_free(p);
-  return code;
 }
 
 EXPORT("close_udp_socket")


### PR DESCRIPTION
lwIP doesn't have built-in destination broadcast support such that sending a UDP packet to 255.255.255.255 would emit it across all interfaces. Logic was previously added to manually support this by iterating through each interfaces and sending the packet, but there was a bug in the logic where it would try to reuse the same `pbuf` across all interfaces, when it really needs to be re-allocated for each.

This PR fixes the logic to allocate a new `pbuf` for each interface. It also adds one more check to ensure the destination interface supports ARP. This implicitly will filter out tap interfaces that have been added to a bridge, since lwIP clears this flag when added to the bridge. We want to filter these out because the bridge itself will handle broadcasting the packet to each of its interfaces.