### PR TITLE
refactor: wasi reactor module instead of command module

### DIFF
--- a/packages/tcpip/Makefile
+++ b/packages/tcpip/Makefile
@@ -1,7 +1,7 @@
 CC ?= clang
 TARGET = wasm32-wasi
 CFLAGS = -Oz -Wall -std=c11
-LDFLAGS = -Wl,--gc-sections,--strip-all,--export=malloc,--export=free,--allow-undefined
+LDFLAGS = -Wl,--gc-sections,--strip-all,--export=malloc,--export=free,--allow-undefined -mexec-model=reactor
 
 SRC_DIR = wasm
 OUTPUT = tcpip.wasm

--- a/packages/tcpip/src/stack.ts
+++ b/packages/tcpip/src/stack.ts
@@ -181,11 +181,9 @@ export class VirtualNetworkStack implements NetworkStack {
     this.#tcpBindings.register(wasmInstance.exports);
     this.#udpBindings.register(wasmInstance.exports);
 
-    const result = wasi.start(wasmInstance);
-
-    if (result !== 0) {
-      throw new Error(`wasi start failed with code ${result}`);
-    }
+    // Our WASM binary is a WASI reactor module (ie. a lib),
+    // so we call `initialize()` instead of `start()`.
+    wasi.initialize(wasmInstance);
 
     // Call lwIP's main loop regularly (required in NO_SYS mode)
     // Used to process queued packets (eg. loopback) and expired timeouts

--- a/packages/tcpip/src/types.ts
+++ b/packages/tcpip/src/types.ts
@@ -17,7 +17,7 @@ export type Pointer = UniquePointer | 0;
 
 export type WasiExports = {
   memory: WebAssembly.Memory;
-  _start(): unknown;
+  _initialize(): unknown;
 };
 
 export type SysExports = {

--- a/packages/tcpip/wasm/stack.c
+++ b/packages/tcpip/wasm/stack.c
@@ -19,6 +19,14 @@ void process_timeouts() {
   sys_check_timeouts();
 }
 
-int main() {
+// Initialize the lwIP stack
+//
+// We compile as a WASI reactor module (ie. a lib) which has no main() function
+// Instead we set up a constructor function which is called when the module is loaded
+//
+// Under the hood, reactor modules call _initialize() as the entry point which
+// wasi-libc implements, and in turn calls __wasm_call_ctors() to run constructors
+// See https://github.com/WebAssembly/wasi-libc/blob/main/libc-bottom-half/crt/crt1-reactor.c
+__attribute__((constructor)) void initialize() {
   lwip_init();
 }


### PR DESCRIPTION
## Background
We compile our lwIP C bindings to WASM using the `wasi-sdk`. By default, WASI modules are compiled as "command modules" which must contain a `main()` function and are treated like synchronous processes (ie. once `main()` exits, the module is terminated). There is another type of WASI module called a "reactor module" which is intended to be used as a library instead of a process.

## Problem
We currently mix these concepts in a way that technically works but is not correct spec-wise. We compile our code as a command module, use `main()` for initialization, then proceed to treat the WASM module as a lib via import/export functions.

## Solution
Compile our WASM file as a WASI reactor module and move our initialization logic outside of `main()` which should no longer exist. On the JS side, we call `initialize()` instead of `start()` on the WASI module. Everything else remains as is.