### PR TITLE
fix: force TCP binding to send the data immediately

### DIFF
--- a/packages/tcpip/src/stack.test.ts
+++ b/packages/tcpip/src/stack.test.ts
@@ -879,7 +879,7 @@ describe('tcp', () => {
     // Check timing - with tcp_output enabled, this should be very fast
     // Without tcp_output, there would be a significant delay (~300ms)
     const elapsed = endTime - startTime;
-    expect(elapsed).toBeLessThan(100);
+    expect(elapsed).toBeLessThan(200);
   });
 });
 

--- a/packages/tcpip/wasm/tcp.c
+++ b/packages/tcpip/wasm/tcp.c
@@ -32,10 +32,10 @@ uint16_t send_tcp_chunk(struct tcp_pcb *conn, uint8_t *chunk, uint16_t length) {
   }
 
   // Force sending chunks immediately
-  // err_t out_result = tcp_output(conn);
-  // if (out_result != ERR_OK) {
-  //   return 0;
-  // }
+  err_t out_result = tcp_output(conn);
+  if (out_result != ERR_OK) {
+    return 0;
+  }
 
   return bytes_to_send;
 }

--- a/packages/tcpip/wasm/tcp.c
+++ b/packages/tcpip/wasm/tcp.c
@@ -31,6 +31,12 @@ uint16_t send_tcp_chunk(struct tcp_pcb *conn, uint8_t *chunk, uint16_t length) {
     return 0;
   }
 
+  // Force sending chunks immediately
+  err_t out_result = tcp_output(conn);
+  if (out_result != ERR_OK) {
+    return 0;
+  }
+
   return bytes_to_send;
 }
 

--- a/packages/tcpip/wasm/tcp.c
+++ b/packages/tcpip/wasm/tcp.c
@@ -32,10 +32,10 @@ uint16_t send_tcp_chunk(struct tcp_pcb *conn, uint8_t *chunk, uint16_t length) {
   }
 
   // Force sending chunks immediately
-  err_t out_result = tcp_output(conn);
-  if (out_result != ERR_OK) {
-    return 0;
-  }
+  // err_t out_result = tcp_output(conn);
+  // if (out_result != ERR_OK) {
+  //   return 0;
+  // }
 
   return bytes_to_send;
 }


### PR DESCRIPTION
Force the `send_tcp_chunk` method to send the data immediately. It avoids waiting for some timeouts when packets are small.

Refs #6  