### PR TITLE
fix: remove release please workspace plugin

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,11 +23,5 @@
     "packages/v86": {
       "component": "@tcpip/v86"
     }
-  },
-  "plugins": [
-    {
-      "type": "node-workspace",
-      "updatePeerDependencies": true
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Removes the `node-workspace` release please plugin that got stuck on our `tcpip` <-> `@tcpip/dns` circular dependency.