### PR TITLE
feat(dhcp): harden lease handling + v86 integration tests

### DIFF
--- a/packages/dhcp/README.md
+++ b/packages/dhcp/README.md
@@ -1,0 +1,120 @@
+# @tcpip/dhcp
+
+> DHCP server for tcpip.js virtual networks.
+
+## Why?
+
+When you connect a VM like v86 to a `tcpip` network, it needs an IP address before you can communicate with it. You can configure that address manually by pre-baking it into the image or running the `ip` command after boot, but this gets tedious and doesn't scale well with multiple VMs. DHCP lets the network manage the IP, gateway, and DNS settings instead. It was designed exactly for this use case.
+
+`@tcpip/dhcp` lets the guest use its normal DHCP client instead. Start a DHCP server on your `tcpip` stack, connect the guest to a tap or bridge interface, and the guest can request an address dynamically. You can also advertise your own DNS server through DHCP, which is useful when you want VMs to resolve names on your virtual network.
+
+## Installation
+
+```shell
+npm i tcpip @tcpip/dhcp
+```
+
+## Usage
+
+```ts
+import { createDhcp } from '@tcpip/dhcp';
+import { createStack } from 'tcpip';
+
+const stack = await createStack();
+
+const tapInterface = await stack.createTapInterface({
+  ip: '192.168.1.1/24',
+});
+
+const dhcp = await createDhcp(stack);
+const server = await dhcp.serve({
+  leaseRange: {
+    start: '192.168.1.100',
+    end: '192.168.1.200',
+  },
+  serverIdentifier: '192.168.1.1',
+  netmask: '255.255.255.0',
+  router: '192.168.1.1',
+  dnsServers: ['192.168.1.1'],
+});
+```
+
+Then connect `tapInterface` to another virtual device. For example, with `@tcpip/v86`:
+
+```ts
+import { createV86NetworkStream } from '@tcpip/v86';
+import { connectStreams } from 'tcpip';
+
+const vmNic = createV86NetworkStream(emulator);
+
+connectStreams(tapInterface, vmNic);
+```
+
+Note that the guest needs to run a DHCP client for this to work. Many Linux images do this during boot, but if yours doesn't you can run something like:
+
+```shell
+udhcpc -i eth0
+```
+
+depending on the DHCP client installed. With v86, you can send commands over the serial console using `emulator.serial0_send(...)`.
+
+## Options
+
+```ts
+type DhcpServerOptions = {
+  leaseRange: {
+    start: string;
+    end: string;
+  };
+  serverIdentifier: string;
+  netmask: string;
+  router: string;
+  leaseDuration?: number;
+  dnsServers?: string[];
+  hostname?: string;
+  domainName?: string;
+  searchDomains?: string[];
+};
+```
+
+- `leaseRange`: IP addresses the server may assign.
+- `serverIdentifier`: IP address of this DHCP server, usually the stack interface IP.
+- `netmask`: subnet mask sent to clients.
+- `router`: default gateway sent to clients.
+- `leaseDuration`: lease lifetime in seconds. Defaults to `86400`.
+- `dnsServers`: DNS servers sent to clients.
+- `hostname`, `domainName`, `searchDomains`: optional host/domain settings sent to clients.
+
+The returned `server` keeps in-memory leases:
+
+```ts
+console.log([...server.leases.values()]);
+```
+
+## Behavior
+
+Supported today:
+
+- DHCP DISCOVER/OFFER
+- DHCP REQUEST/ACK
+- DHCP RELEASE
+- lease renewal via `ciaddr`
+- short-lived offer reservations to avoid duplicate concurrent offers
+- UDP broadcast over `tcpip`
+
+If the lease range is exhausted, the server does not send an offer.
+
+## Limitations
+
+This is an MVP DHCP server API for virtual networks. It does not currently support:
+
+- persistent leases
+- static MAC reservations
+- DHCP client mode
+- DHCP DECLINE or INFORM
+- client identifier option matching
+- lease event callbacks
+
+## License
+
+MIT

--- a/packages/dhcp/src/dhcp-server.test.ts
+++ b/packages/dhcp/src/dhcp-server.test.ts
@@ -1,0 +1,384 @@
+import type { NetworkStack, UdpDatagram, UdpSocket } from 'tcpip/types';
+import { describe, expect, it } from 'vitest';
+import {
+  DHCP_SERVER_PORT,
+  DhcpMessageTypes,
+  DhcpOptions,
+} from './constants.js';
+import { DhcpServer, type DhcpServerOptions } from './dhcp-server.js';
+import { parseDhcpMessage } from './wire.js';
+
+const defaultOptions: DhcpServerOptions = {
+  leaseRange: { start: '192.168.1.100', end: '192.168.1.102' },
+  leaseDuration: 3600,
+  serverIdentifier: '192.168.1.1',
+  netmask: '255.255.255.0',
+  router: '192.168.1.1',
+};
+
+class AsyncQueue<T> implements AsyncIterable<T> {
+  #values: T[] = [];
+  #waiters: Array<(value: IteratorResult<T>) => void> = [];
+  #closed = false;
+
+  push(value: T) {
+    const waiter = this.#waiters.shift();
+    if (waiter) {
+      waiter({ value, done: false });
+      return;
+    }
+    this.#values.push(value);
+  }
+
+  close() {
+    this.#closed = true;
+    for (const waiter of this.#waiters.splice(0)) {
+      waiter({ value: undefined, done: true });
+    }
+  }
+
+  async next(): Promise<IteratorResult<T>> {
+    const value = this.#values.shift();
+    if (value) {
+      return { value, done: false };
+    }
+    if (this.#closed) {
+      return { value: undefined, done: true };
+    }
+    return await new Promise((resolve) => {
+      this.#waiters.push(resolve);
+    });
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return this;
+  }
+}
+
+class TestUdpSocket implements UdpSocket, AsyncIterable<UdpDatagram> {
+  #incoming = new AsyncQueue<UdpDatagram>();
+  #outgoing = new AsyncQueue<UdpDatagram>();
+
+  readable = new ReadableStream<UdpDatagram>();
+  writable = new WritableStream<UdpDatagram>({
+    write: async (datagram) => {
+      this.#outgoing.push(datagram);
+    },
+  });
+
+  receive(data: Uint8Array) {
+    this.#incoming.push({
+      host: '0.0.0.0',
+      port: 68,
+      data,
+    });
+  }
+
+  async nextReply() {
+    const result = await this.#outgoing.next();
+    if (result.done) {
+      throw new Error('expected udp reply');
+    }
+    return result.value;
+  }
+
+  async nextReplyMessage() {
+    return parseDhcpMessage((await this.nextReply()).data);
+  }
+
+  async maybeNextReply(timeoutMs = 50) {
+    return await Promise.race([
+      this.nextReply(),
+      new Promise<undefined>((resolve) => {
+        setTimeout(() => resolve(undefined), timeoutMs);
+      }),
+    ]);
+  }
+
+  async close() {
+    this.#incoming.close();
+    this.#outgoing.close();
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<UdpDatagram> {
+    return this.#incoming[Symbol.asyncIterator]();
+  }
+}
+
+class TestNetworkStack implements Partial<NetworkStack> {
+  socket = new TestUdpSocket();
+
+  async openUdp(options = {}) {
+    expect(options).toEqual({ port: DHCP_SERVER_PORT });
+    return this.socket;
+  }
+}
+
+function createClientMessage({
+  mac,
+  type,
+  xid = 0x12345678,
+  ciaddr = '0.0.0.0',
+  requestedIP,
+  serverIdentifier,
+}: {
+  mac: string;
+  type: number;
+  xid?: number;
+  ciaddr?: string;
+  requestedIP?: string;
+  serverIdentifier?: string;
+}) {
+  const data = new Uint8Array(260);
+  const view = new DataView(data.buffer);
+  view.setUint8(0, 1);
+  view.setUint8(1, 1);
+  view.setUint8(2, 6);
+  view.setUint32(4, xid);
+  data.set(ciaddr.split('.').map(Number), 12);
+  data.set(
+    mac.split(':').map((part) => Number.parseInt(part, 16)),
+    28
+  );
+  view.setUint32(236, 0x63825363);
+
+  let offset = 240;
+  data[offset++] = DhcpOptions.MESSAGE_TYPE;
+  data[offset++] = 1;
+  data[offset++] = type;
+
+  if (requestedIP) {
+    data[offset++] = 50;
+    data[offset++] = 4;
+    data.set(requestedIP.split('.').map(Number), offset);
+    offset += 4;
+  }
+
+  if (serverIdentifier) {
+    data[offset++] = DhcpOptions.SERVER_IDENTIFIER;
+    data[offset++] = 4;
+    data.set(serverIdentifier.split('.').map(Number), offset);
+    offset += 4;
+  }
+
+  data[offset++] = DhcpOptions.END;
+  return data.slice(0, offset);
+}
+
+async function createTestServer(options = defaultOptions) {
+  const stack = new TestNetworkStack();
+  const server = new DhcpServer(stack as unknown as NetworkStack, options);
+  await server.listen();
+  return { server, socket: stack.socket };
+}
+
+describe('DhcpServer', () => {
+  it('should reserve offered IPs before leases are committed', async () => {
+    const { socket } = await createTestServer();
+
+    socket.receive(
+      createClientMessage({
+        mac: '00:11:22:33:44:55',
+        type: DhcpMessageTypes.DISCOVER,
+      })
+    );
+    socket.receive(
+      createClientMessage({
+        mac: '00:11:22:33:44:66',
+        type: DhcpMessageTypes.DISCOVER,
+      })
+    );
+
+    const firstOffer = await socket.nextReplyMessage();
+    const secondOffer = await socket.nextReplyMessage();
+
+    expect(firstOffer.type).toBe('OFFER');
+    expect(firstOffer.yiaddr).toBe('192.168.1.100');
+    expect(secondOffer.type).toBe('OFFER');
+    expect(secondOffer.yiaddr).toBe('192.168.1.101');
+
+    await socket.close();
+  });
+
+  it('should ack the exact requested IP from this server offer', async () => {
+    const { server, socket } = await createTestServer();
+
+    socket.receive(
+      createClientMessage({
+        mac: '00:11:22:33:44:55',
+        type: DhcpMessageTypes.DISCOVER,
+      })
+    );
+    const offer = await socket.nextReplyMessage();
+
+    socket.receive(
+      createClientMessage({
+        mac: '00:11:22:33:44:55',
+        type: DhcpMessageTypes.REQUEST,
+        requestedIP: offer.yiaddr,
+        serverIdentifier: defaultOptions.serverIdentifier,
+      })
+    );
+    const ack = await socket.nextReplyMessage();
+
+    expect(ack.type).toBe('ACK');
+    expect(ack.yiaddr).toBe(offer.yiaddr);
+    expect(server.leases.get('00:11:22:33:44:55')?.ip).toBe(offer.yiaddr);
+
+    await socket.close();
+  });
+
+  it('should ignore requests for another DHCP server', async () => {
+    const { socket } = await createTestServer();
+
+    socket.receive(
+      createClientMessage({
+        mac: '00:11:22:33:44:55',
+        type: DhcpMessageTypes.REQUEST,
+        requestedIP: '192.168.1.100',
+        serverIdentifier: '192.168.1.254',
+      })
+    );
+
+    const result = await socket.maybeNextReply();
+
+    expect(result).toBeUndefined();
+
+    await socket.close();
+  });
+
+  it('should renew leases using ciaddr', async () => {
+    const { server, socket } = await createTestServer();
+
+    server.leases.set('00:11:22:33:44:55', {
+      ip: '192.168.1.100',
+      mac: '00:11:22:33:44:55',
+      expiresAt: Date.now() + 1000,
+    });
+
+    socket.receive(
+      createClientMessage({
+        mac: '00:11:22:33:44:55',
+        type: DhcpMessageTypes.REQUEST,
+        ciaddr: '192.168.1.100',
+      })
+    );
+    const ack = await socket.nextReplyMessage();
+
+    expect(ack.type).toBe('ACK');
+    expect(ack.yiaddr).toBe('192.168.1.100');
+    expect(server.leases.get('00:11:22:33:44:55')!.expiresAt).toBeGreaterThan(
+      Date.now() + 1000
+    );
+
+    await socket.close();
+  });
+
+  it('should not offer an IP when the lease range is exhausted', async () => {
+    const { socket } = await createTestServer({
+      ...defaultOptions,
+      leaseRange: { start: '192.168.1.100', end: '192.168.1.100' },
+    });
+
+    socket.receive(
+      createClientMessage({
+        mac: '00:11:22:33:44:55',
+        type: DhcpMessageTypes.DISCOVER,
+      })
+    );
+    socket.receive(
+      createClientMessage({
+        mac: '00:11:22:33:44:66',
+        type: DhcpMessageTypes.DISCOVER,
+      })
+    );
+
+    const offer = await socket.nextReplyMessage();
+    const exhaustedReply = await socket.maybeNextReply();
+
+    expect(offer.type).toBe('OFFER');
+    expect(offer.yiaddr).toBe('192.168.1.100');
+    expect(exhaustedReply).toBeUndefined();
+
+    await socket.close();
+  });
+
+  it('should nak requests for IPs outside the lease range', async () => {
+    const { socket } = await createTestServer();
+
+    socket.receive(
+      createClientMessage({
+        mac: '00:11:22:33:44:55',
+        type: DhcpMessageTypes.REQUEST,
+        requestedIP: '192.168.1.200',
+        serverIdentifier: defaultOptions.serverIdentifier,
+      })
+    );
+    const nak = await socket.nextReplyMessage();
+
+    expect(nak.type).toBe('NAK');
+    expect(nak.yiaddr).toBe('0.0.0.0');
+
+    await socket.close();
+  });
+
+  it('should nak requests for IPs offered to another client', async () => {
+    const { socket } = await createTestServer();
+
+    socket.receive(
+      createClientMessage({
+        mac: '00:11:22:33:44:55',
+        type: DhcpMessageTypes.DISCOVER,
+      })
+    );
+    const offer = await socket.nextReplyMessage();
+
+    socket.receive(
+      createClientMessage({
+        mac: '00:11:22:33:44:66',
+        type: DhcpMessageTypes.REQUEST,
+        requestedIP: offer.yiaddr,
+        serverIdentifier: defaultOptions.serverIdentifier,
+      })
+    );
+    const nak = await socket.nextReplyMessage();
+
+    expect(nak.type).toBe('NAK');
+    expect(nak.yiaddr).toBe('0.0.0.0');
+
+    await socket.close();
+  });
+
+  it('should release leases so IPs can be offered again', async () => {
+    const { server, socket } = await createTestServer({
+      ...defaultOptions,
+      leaseRange: { start: '192.168.1.100', end: '192.168.1.100' },
+    });
+
+    server.leases.set('00:11:22:33:44:55', {
+      ip: '192.168.1.100',
+      mac: '00:11:22:33:44:55',
+      expiresAt: Date.now() + 60_000,
+    });
+
+    socket.receive(
+      createClientMessage({
+        mac: '00:11:22:33:44:55',
+        type: DhcpMessageTypes.RELEASE,
+      })
+    );
+    socket.receive(
+      createClientMessage({
+        mac: '00:11:22:33:44:66',
+        type: DhcpMessageTypes.DISCOVER,
+      })
+    );
+    const offer = await socket.nextReplyMessage();
+
+    expect(server.leases.has('00:11:22:33:44:55')).toBe(false);
+    expect(offer.type).toBe('OFFER');
+    expect(offer.yiaddr).toBe('192.168.1.100');
+
+    await socket.close();
+  });
+});

--- a/packages/dhcp/src/dhcp-server.ts
+++ b/packages/dhcp/src/dhcp-server.ts
@@ -8,6 +8,8 @@ import type { DhcpLease, DhcpMessage } from './types.js';
 import { ipv4ToNumber, numberToIPv4 } from './util.js';
 import { parseDhcpMessage, serializeDhcpMessage } from './wire.js';
 
+const OFFER_DURATION_MS = 60_000;
+
 export type DhcpServerOptions = {
   /**
    * Range of IP addresses to lease.
@@ -63,6 +65,7 @@ export class DhcpServer {
   #options: DhcpServerOptions;
 
   leases = new Map<string, DhcpLease>();
+  #offers = new Map<string, DhcpLease>();
 
   constructor(stack: NetworkStack, options: DhcpServerOptions) {
     this.#stack = stack;
@@ -120,16 +123,25 @@ export class DhcpServer {
   }
 
   #findAvailableIP(mac: string) {
+    this.#deleteExpiredAllocations();
+
     const existingLease = this.leases.get(mac);
     if (existingLease && existingLease.expiresAt > Date.now()) {
       return existingLease.ip;
+    }
+
+    const existingOffer = this.#offers.get(mac);
+    if (existingOffer && existingOffer.expiresAt > Date.now()) {
+      return existingOffer.ip;
     }
 
     const start = ipv4ToNumber(this.#options.leaseRange.start);
     const end = ipv4ToNumber(this.#options.leaseRange.end);
 
     const usedIPs = new Set(
-      Array.from(this.leases.values()).map((lease) => lease.ip)
+      [...this.leases.values(), ...this.#offers.values()].map(
+        (lease) => lease.ip
+      )
     );
 
     for (let i = start; i <= end; i++) {
@@ -140,11 +152,17 @@ export class DhcpServer {
     }
   }
 
-  #handleDiscover(message: DhcpMessage): UdpDatagram {
+  #handleDiscover(message: DhcpMessage): UdpDatagram | undefined {
     const ip = this.#findAvailableIP(message.mac);
     if (!ip) {
-      return this.#createNak(message);
+      return;
     }
+
+    this.#offers.set(message.mac, {
+      ip,
+      mac: message.mac,
+      expiresAt: Date.now() + OFFER_DURATION_MS,
+    });
 
     const offer = serializeDhcpMessage(
       {
@@ -165,46 +183,41 @@ export class DhcpServer {
   }
 
   #handleRequest(message: DhcpMessage): UdpDatagram | undefined {
-    // Determine if this is a response to our offer or a direct request
-    const isResponseToOffer =
-      message.serverIdentifier === this.#options.serverIdentifier;
+    this.#deleteExpiredAllocations();
 
-    let assignedIP: string | undefined = undefined;
+    if (
+      message.serverIdentifier &&
+      message.serverIdentifier !== this.#options.serverIdentifier
+    ) {
+      return;
+    }
 
-    if (isResponseToOffer) {
-      // Client is accepting our offer
-      assignedIP = this.#findAvailableIP(message.mac);
-      if (!assignedIP) {
-        return this.#createNak(message);
-      }
-    } else if (message.requestedIP) {
-      // Client is requesting a specific IP
-      const canUseRequestedIp = this.#canUseRequestedIP(
-        message.requestedIP,
-        message.mac
-      );
-      if (canUseRequestedIp) {
-        assignedIP = message.requestedIP;
-      } else {
-        return this.#createNak(message);
-      }
-    } else {
-      // Malformed REQUEST - no way to know what IP to assign
+    const requestedIP =
+      message.requestedIP ??
+      (message.ciaddr !== '0.0.0.0' ? message.ciaddr : undefined);
+
+    if (!requestedIP) {
       return this.#createNak(message);
     }
 
-    // If we got here, we have a valid IP to assign
-    this.leases.set(message.mac, {
-      ip: assignedIP,
-      mac: message.mac,
-      expiresAt: Date.now() + this.#options.leaseDuration! * 1000,
-    });
+    const canUseRequestedIP = this.#canUseRequestedIP(requestedIP, message.mac);
+    if (canUseRequestedIP) {
+      this.leases.set(message.mac, {
+        ip: requestedIP,
+        mac: message.mac,
+        expiresAt: Date.now() + this.#options.leaseDuration! * 1000,
+      });
+      this.#offers.delete(message.mac);
+    } else {
+      this.#offers.delete(message.mac);
+      return this.#createNak(message);
+    }
 
     const ack = serializeDhcpMessage(
       {
         op: 2,
         xid: message.xid,
-        yiaddr: assignedIP,
+        yiaddr: requestedIP,
         mac: message.mac,
         type: DhcpMessageTypes.ACK,
       },
@@ -220,6 +233,7 @@ export class DhcpServer {
 
   #handleRelease(message: DhcpMessage) {
     this.leases.delete(message.mac);
+    this.#offers.delete(message.mac);
   }
 
   #createNak(message: DhcpMessage): UdpDatagram {
@@ -252,7 +266,10 @@ export class DhcpServer {
     }
 
     // Check if IP is in use by another client
-    for (const [mac, lease] of this.leases.entries()) {
+    for (const [mac, lease] of [
+      ...this.leases.entries(),
+      ...this.#offers.entries(),
+    ]) {
       if (lease.ip === requestedIP) {
         // IP is in use, but check if it's by this same client
         return mac === clientMac && lease.expiresAt > Date.now();
@@ -261,5 +278,19 @@ export class DhcpServer {
 
     // IP is in our range and not in use
     return true;
+  }
+
+  #deleteExpiredAllocations() {
+    const now = Date.now();
+    for (const [mac, lease] of this.leases.entries()) {
+      if (lease.expiresAt <= now) {
+        this.leases.delete(mac);
+      }
+    }
+    for (const [mac, offer] of this.#offers.entries()) {
+      if (offer.expiresAt <= now) {
+        this.#offers.delete(mac);
+      }
+    }
   }
 }

--- a/packages/dhcp/src/dhcp-stack.test.ts
+++ b/packages/dhcp/src/dhcp-stack.test.ts
@@ -1,0 +1,219 @@
+import {
+  type EthernetFrame,
+  parseEthernetFrame,
+  serializeEthernetFrame,
+} from '@tcpip/wire';
+import { createStack } from 'tcpip';
+import { describe, expect, it } from 'vitest';
+import { DHCP_CLIENT_PORT, DHCP_SERVER_PORT } from './constants.js';
+import { createDhcp } from './index.js';
+import { parseDhcpMessage } from './wire.js';
+
+const clientMac = '02:00:00:00:00:02';
+
+function getOptionData(message: Uint8Array, optionCode: number) {
+  let offset = 240;
+  while (offset < message.length) {
+    const option = message[offset];
+    if (option === 255) {
+      return;
+    }
+    if (option === 0) {
+      offset += 1;
+      continue;
+    }
+
+    const length = message[offset + 1]!;
+    const dataOffset = offset + 2;
+    if (option === optionCode) {
+      return message.subarray(dataOffset, dataOffset + length);
+    }
+    offset = dataOffset + length;
+  }
+}
+
+function createDhcpClientMessage({
+  type,
+  xid = 0x12345678,
+  requestedIP,
+  serverIdentifier,
+}: {
+  type: number;
+  xid?: number;
+  requestedIP?: string;
+  serverIdentifier?: string;
+}) {
+  const data = new Uint8Array(260);
+  const view = new DataView(data.buffer);
+  view.setUint8(0, 1);
+  view.setUint8(1, 1);
+  view.setUint8(2, 6);
+  view.setUint32(4, xid);
+  data.set(
+    clientMac.split(':').map((part) => Number.parseInt(part, 16)),
+    28
+  );
+  view.setUint32(236, 0x63825363);
+
+  let offset = 240;
+  data[offset++] = 53;
+  data[offset++] = 1;
+  data[offset++] = type;
+
+  if (requestedIP) {
+    data[offset++] = 50;
+    data[offset++] = 4;
+    data.set(requestedIP.split('.').map(Number), offset);
+    offset += 4;
+  }
+
+  if (serverIdentifier) {
+    data[offset++] = 54;
+    data[offset++] = 4;
+    data.set(serverIdentifier.split('.').map(Number), offset);
+    offset += 4;
+  }
+
+  data[offset++] = 255;
+  return data.slice(0, offset);
+}
+
+function createClientFrame(payload: Uint8Array): Uint8Array {
+  const frame: EthernetFrame = {
+    destinationMac: 'ff:ff:ff:ff:ff:ff',
+    sourceMac: clientMac,
+    type: 'ipv4',
+    payload: {
+      version: 4,
+      dscp: 0,
+      ecn: 0,
+      identification: 0,
+      flags: 0,
+      fragmentOffset: 0,
+      ttl: 64,
+      protocol: 'udp',
+      sourceIP: '0.0.0.0',
+      destinationIP: '255.255.255.255',
+      payload: {
+        sourcePort: DHCP_CLIENT_PORT,
+        destinationPort: DHCP_SERVER_PORT,
+        payload,
+      },
+    },
+  };
+
+  return serializeEthernetFrame(frame);
+}
+
+async function waitForDhcpReply(iterator: AsyncIterator<Uint8Array>) {
+  return await Promise.race([
+    (async () => {
+      while (true) {
+        const { value, done } = await iterator.next();
+        if (done) {
+          throw new Error('iterator done');
+        }
+
+        const frame = parseEthernetFrame(value);
+        if (frame.type !== 'ipv4' || frame.payload.protocol !== 'udp') {
+          continue;
+        }
+
+        const udp = frame.payload.payload;
+        if (udp.destinationPort === DHCP_CLIENT_PORT) {
+          return {
+            message: parseDhcpMessage(udp.payload),
+            payload: udp.payload,
+          };
+        }
+      }
+    })(),
+    new Promise<never>((_, reject) => {
+      setTimeout(
+        () => reject(new Error('timed out waiting for DHCP reply')),
+        1_000
+      );
+    }),
+  ]);
+}
+
+describe('DhcpServer with tcpip stack', () => {
+  it('should complete discover/request over UDP broadcast', async () => {
+    const stack = await createStack();
+    const tapInterface = await stack.createTapInterface({
+      ip: '192.168.1.1/24',
+      mac: '02:00:00:00:00:01',
+    });
+    const dhcp = await createDhcp(stack);
+    const dhcpServer = await dhcp.serve({
+      leaseRange: { start: '192.168.1.100', end: '192.168.1.110' },
+      leaseDuration: 3600,
+      serverIdentifier: '192.168.1.1',
+      netmask: '255.255.255.0',
+      router: '192.168.1.1',
+    });
+
+    const listener = tapInterface.listen();
+    const writer = tapInterface.writable.getWriter();
+
+    await writer.write(
+      createClientFrame(
+        createDhcpClientMessage({
+          type: 1,
+        })
+      )
+    );
+    const offer = await waitForDhcpReply(listener);
+
+    expect(offer.message.type).toBe('OFFER');
+    expect(offer.message.yiaddr).toBe('192.168.1.100');
+
+    await writer.write(
+      createClientFrame(
+        createDhcpClientMessage({
+          type: 3,
+          requestedIP: offer.message.yiaddr,
+          serverIdentifier: '192.168.1.1',
+        })
+      )
+    );
+    const ack = await waitForDhcpReply(listener);
+
+    expect(ack.message.type).toBe('ACK');
+    expect(ack.message.yiaddr).toBe(offer.message.yiaddr);
+    expect(dhcpServer.leases.get(clientMac)?.ip).toBe(offer.message.yiaddr);
+  });
+
+  it('should advertise configured DNS servers', async () => {
+    const stack = await createStack();
+    const tapInterface = await stack.createTapInterface({
+      ip: '192.168.1.1/24',
+      mac: '02:00:00:00:00:01',
+    });
+    const dhcp = await createDhcp(stack);
+    await dhcp.serve({
+      leaseRange: { start: '192.168.1.100', end: '192.168.1.110' },
+      leaseDuration: 3600,
+      serverIdentifier: '192.168.1.1',
+      netmask: '255.255.255.0',
+      router: '192.168.1.1',
+      dnsServers: ['192.168.1.1', '192.168.1.2'],
+    });
+
+    const listener = tapInterface.listen();
+    const writer = tapInterface.writable.getWriter();
+
+    await writer.write(
+      createClientFrame(
+        createDhcpClientMessage({
+          type: 1,
+        })
+      )
+    );
+    const offer = await waitForDhcpReply(listener);
+
+    expect(getOptionData(offer.payload, 6)).toEqual(
+      new Uint8Array([192, 168, 1, 1, 192, 168, 1, 2])
+    );
+  });
+});

--- a/packages/dhcp/src/types.ts
+++ b/packages/dhcp/src/types.ts
@@ -22,6 +22,8 @@ export type DhcpMessage = {
   htype: number;
   hlen: number;
   xid: number;
+  ciaddr: string;
+  yiaddr: string;
   mac: string;
   type?: DhcpMessageType;
   requestedIP?: string;

--- a/packages/dhcp/src/wire.test.ts
+++ b/packages/dhcp/src/wire.test.ts
@@ -60,9 +60,11 @@ describe('parseDhcpMessage', () => {
       htype: 2,
       hlen: 6,
       xid: 0x12345678,
+      ciaddr: '0.0.0.0',
+      yiaddr: '0.0.0.0',
       mac: '11:22:33:44:55:66',
       type: undefined,
-      requestedIp: undefined,
+      requestedIP: undefined,
       serverIdentifier: undefined,
     });
   });
@@ -100,11 +102,68 @@ describe('parseDhcpMessage', () => {
       htype: 1,
       hlen: 6,
       xid: 0x12345678,
+      ciaddr: '0.0.0.0',
+      yiaddr: '0.0.0.0',
       mac: '11:22:33:44:55:66',
       type: 'DISCOVER',
       requestedIP: '192.168.1.100',
       serverIdentifier: undefined,
     });
+  });
+
+  it('should parse DHCP options after pad bytes', () => {
+    const data = new Uint8Array(244);
+    const view = new DataView(data.buffer);
+
+    view.setUint8(0, 1);
+    view.setUint8(1, 1);
+    view.setUint8(2, 6);
+    view.setUint32(4, 0x12345678);
+    [0x11, 0x22, 0x33, 0x44, 0x55, 0x66].forEach((byte, i) =>
+      view.setUint8(28 + i, byte)
+    );
+
+    data[240] = 0; // PAD
+    data[241] = DhcpOptions.MESSAGE_TYPE;
+    data[242] = 1;
+    data[243] = DhcpMessageTypes.DISCOVER;
+
+    expect(parseDhcpMessage(data).type).toBe('DISCOVER');
+  });
+
+  it('should parse fields from a sliced buffer', () => {
+    const buffer = new Uint8Array(260);
+    const data = buffer.subarray(10, 254);
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+
+    view.setUint8(0, 1);
+    view.setUint8(1, 1);
+    view.setUint8(2, 6);
+    view.setUint32(4, 0x12345678);
+    data.set([192, 168, 1, 25], 12);
+    [0x11, 0x22, 0x33, 0x44, 0x55, 0x66].forEach((byte, i) =>
+      view.setUint8(28 + i, byte)
+    );
+    data[240] = DhcpOptions.MESSAGE_TYPE;
+    data[241] = 1;
+    data[242] = DhcpMessageTypes.REQUEST;
+    data[243] = DhcpOptions.END;
+
+    const message = parseDhcpMessage(data);
+
+    expect(message.xid).toBe(0x12345678);
+    expect(message.ciaddr).toBe('192.168.1.25');
+    expect(message.mac).toBe('11:22:33:44:55:66');
+    expect(message.type).toBe('REQUEST');
+  });
+
+  it('should throw on truncated DHCP options', () => {
+    const data = new Uint8Array(243);
+    data[240] = DhcpOptions.MESSAGE_TYPE;
+    data[241] = 4;
+    data[242] = DhcpMessageTypes.DISCOVER;
+
+    expect(() => parseDhcpMessage(data)).toThrow('truncated dhcp option');
   });
 });
 
@@ -222,5 +281,31 @@ describe('serializeDhcpMessage', () => {
 
     expect(result[offset]).toBe(DhcpOptions.DOMAIN_NAME);
     expect(result[offset + 1]).toBe(11); // length of 'example.com'
+  });
+
+  it('should size the options buffer for optional string fields', () => {
+    const params = {
+      op: 2,
+      type: DhcpMessageTypes.OFFER,
+      xid: 0x12345678,
+      yiaddr: '192.168.1.100',
+      mac: '11:22:33:44:55:66',
+    };
+
+    const options: DhcpServerOptions = {
+      serverIdentifier: '192.168.1.1',
+      leaseDuration: 3600,
+      netmask: '255.255.255.0',
+      router: '192.168.1.1',
+      hostname: 'test-host',
+      domainName: 'example.com',
+      searchDomains: ['eng.example.com', 'example.com'],
+      dnsServers: ['10.0.0.1', '10.0.0.2'],
+      leaseRange: { start: '192.168.1.100', end: '192.168.1.200' },
+    };
+
+    const result = serializeDhcpMessage(params, options);
+
+    expect(result.at(-1)).toBe(DhcpOptions.END);
   });
 });

--- a/packages/dhcp/src/wire.ts
+++ b/packages/dhcp/src/wire.ts
@@ -47,15 +47,17 @@ export function parseDhcpMessage(data: Uint8Array): DhcpMessage {
     throw new Error('dhcp message too short');
   }
 
-  const view = new DataView(data.buffer);
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
 
   const op = view.getUint8(0);
   const htype = view.getUint8(1);
   const hlen = view.getUint8(2);
   const xid = view.getUint32(4);
+  const ciaddr = parseIPv4Address(data.subarray(12, 16));
+  const yiaddr = parseIPv4Address(data.subarray(16, 20));
 
   // Get the client's MAC address from the chaddr field
-  const macBytes = new Uint8Array(data.buffer, 28, 6);
+  const macBytes = data.subarray(28, 34);
   const mac = Array.from(macBytes)
     .map((b) => b.toString(16).padStart(2, '0'))
     .join(':');
@@ -69,20 +71,45 @@ export function parseDhcpMessage(data: Uint8Array): DhcpMessage {
   while (i < data.length) {
     const option = data[i];
     if (option === DhcpOptions.END) break;
+    if (option === 0) {
+      i += 1;
+      continue;
+    }
+
+    if (i + 1 >= data.length) {
+      throw new Error('truncated dhcp option');
+    }
 
     const len = data[i + 1]!;
+    const valueOffset = i + 2;
+    const nextOptionOffset = valueOffset + len;
+
+    if (nextOptionOffset > data.length) {
+      throw new Error('truncated dhcp option');
+    }
 
     switch (option) {
       case DhcpOptions.MESSAGE_TYPE:
-        type = parseDhcpMessageType(data[i + 2]!);
+        if (len !== 1) {
+          throw new Error('invalid dhcp message type option length');
+        }
+        type = parseDhcpMessageType(data[valueOffset]!);
         break;
       case DhcpOptionCodes.REQUESTED_IP: {
-        const ip = data.subarray(i + 2, i + 2 + 4);
+        if (len !== 4) {
+          throw new Error('invalid dhcp requested ip option length');
+        }
+        const ip = data.subarray(valueOffset, nextOptionOffset);
         requestedIp = parseIPv4Address(ip);
         break;
       }
       case DhcpOptionCodes.SERVER_ID:
-        serverIdentifier = Array.from(data.slice(i + 2, i + 2 + 4)).join('.');
+        if (len !== 4) {
+          throw new Error('invalid dhcp server identifier option length');
+        }
+        serverIdentifier = parseIPv4Address(
+          data.subarray(valueOffset, nextOptionOffset)
+        );
         break;
     }
 
@@ -94,6 +121,8 @@ export function parseDhcpMessage(data: Uint8Array): DhcpMessage {
     htype,
     hlen,
     xid,
+    ciaddr,
+    yiaddr,
     mac,
     type,
     requestedIP: requestedIp,
@@ -106,11 +135,39 @@ export function serializeDhcpMessage(
   options: DhcpServerOptions
 ): Uint8Array {
   const baseSize = 240;
-  const optionsSize = 64 + (options.dnsServers?.length ?? 0) * 4;
+  const textEncoder = new TextEncoder();
+  const hostnameBytes = options.hostname
+    ? textEncoder.encode(options.hostname)
+    : undefined;
+  const domainBytes = options.domainName
+    ? textEncoder.encode(options.domainName)
+    : undefined;
+  const encodedSearchDomains = options.searchDomains?.map((domain) => {
+    const labels = domain.split('.');
+    const bytes: number[] = [];
+    for (const label of labels) {
+      const labelBytes = textEncoder.encode(label);
+      bytes.push(labelBytes.length);
+      bytes.push(...labelBytes);
+    }
+    bytes.push(0); // Root label
+    return bytes;
+  });
+  const searchDomainsSize =
+    encodedSearchDomains?.reduce((sum, domain) => sum + domain.length, 0) ?? 0;
+  const optionsSize =
+    3 + // message type
+    6 + // server identifier
+    6 + // lease time
+    6 + // subnet mask
+    6 + // router
+    (options.dnsServers?.length ? 2 + options.dnsServers.length * 4 : 0) +
+    (hostnameBytes ? 2 + hostnameBytes.length : 0) +
+    (domainBytes ? 2 + domainBytes.length : 0) +
+    (searchDomainsSize ? 2 + searchDomainsSize : 0) +
+    1; // end
   const message = new Uint8Array(baseSize + optionsSize);
   const view = new DataView(message.buffer);
-
-  const textEncoder = new TextEncoder();
 
   // Set message header fields
   view.setUint8(0, params.op);
@@ -176,8 +233,7 @@ export function serializeDhcpMessage(
   }
 
   // Hostname (if configured)
-  if (options.hostname) {
-    const hostnameBytes = textEncoder.encode(options.hostname);
+  if (hostnameBytes) {
     message[offset++] = DhcpOptions.HOSTNAME;
     message[offset++] = hostnameBytes.length;
     message.set(hostnameBytes, offset);
@@ -185,8 +241,7 @@ export function serializeDhcpMessage(
   }
 
   // Domain Name (if configured)
-  if (options.domainName) {
-    const domainBytes = textEncoder.encode(options.domainName);
+  if (domainBytes) {
     message[offset++] = DhcpOptions.DOMAIN_NAME;
     message[offset++] = domainBytes.length;
     message.set(domainBytes, offset);
@@ -194,28 +249,11 @@ export function serializeDhcpMessage(
   }
 
   // Domain Search (if configured)
-  if (options.searchDomains?.length) {
-    // Calculate total length including length bytes for each domain
-    const encodedDomains = options.searchDomains.map((domain) => {
-      const labels = domain.split('.');
-      const bytes: number[] = [];
-      for (const label of labels) {
-        bytes.push(label.length);
-        bytes.push(...textEncoder.encode(label));
-      }
-      bytes.push(0); // Root label
-      return bytes;
-    });
-
-    const totalLength = encodedDomains.reduce(
-      (sum, domain) => sum + domain.length,
-      0
-    );
-
+  if (encodedSearchDomains?.length && searchDomainsSize > 0) {
     message[offset++] = DhcpOptions.DOMAIN_SEARCH;
-    message[offset++] = totalLength;
+    message[offset++] = searchDomainsSize;
 
-    for (const domainBytes of encodedDomains) {
+    for (const domainBytes of encodedSearchDomains) {
       message.set(domainBytes, offset);
       offset += domainBytes.length;
     }

--- a/packages/v86/package.json
+++ b/packages/v86/package.json
@@ -27,6 +27,7 @@
     }
   },
   "devDependencies": {
+    "@tcpip/dhcp": "workspace:*",
     "@tcpip/wire": "workspace:*",
     "@total-typescript/tsconfig": "catalog:",
     "@types/node": "catalog:",

--- a/packages/v86/src/network-adapter.test.ts
+++ b/packages/v86/src/network-adapter.test.ts
@@ -1,9 +1,42 @@
+import { createDhcp } from '@tcpip/dhcp';
 import { type TcpSegment, parseEthernetFrame } from '@tcpip/wire';
 import { connectStreams, createStack } from 'tcpip';
 import { describe, expect, it } from 'vitest';
 import { createVm, nextValue } from '../test/util.js';
 
 describe('network adapter', () => {
+  it('should assign an IP address and DNS server to a VM with DHCP', async () => {
+    const networkStack = await createStack();
+    const tapInterface = await networkStack.createTapInterface({
+      ip: '192.168.1.1/24',
+    });
+    const dhcp = await createDhcp(networkStack);
+    const dhcpServer = await dhcp.serve({
+      leaseRange: { start: '192.168.1.100', end: '192.168.1.110' },
+      serverIdentifier: '192.168.1.1',
+      netmask: '255.255.255.0',
+      router: '192.168.1.1',
+      dnsServers: ['192.168.1.1'],
+      leaseDuration: 3600,
+    });
+
+    const { emulator, net, executeCommand } = await createVm();
+    connectStreams(tapInterface, net);
+
+    const dhcpOutput = await executeCommand('udhcpc -n -i eth0 -t 3 -T 2');
+    const addressOutput = await executeCommand('ip -4 addr show dev eth0');
+    const resolvConf = await executeCommand('cat /etc/resolv.conf');
+
+    expect(dhcpOutput).toContain('lease of 192.168.1.100 obtained');
+    expect(addressOutput).toContain('inet 192.168.1.100/24');
+    expect(resolvConf).toContain('nameserver 192.168.1.1');
+    expect([...dhcpServer.leases.values()]).toEqual([
+      expect.objectContaining({ ip: '192.168.1.100' }),
+    ]);
+
+    await emulator.destroy();
+  });
+
   it('should make tcp connection from VM to host', async () => {
     const networkStack = await createStack();
     const tapInterface = await networkStack.createTapInterface({

--- a/packages/v86/test/util.ts
+++ b/packages/v86/test/util.ts
@@ -53,14 +53,14 @@ export async function downloadFile(url: string, path: string) {
 }
 
 export type CreateVmOptions = {
-  ip: string;
+  ip?: string;
   promptSequence?: string;
 };
 
 export async function createVm({
   ip,
   promptSequence = '~% ',
-}: CreateVmOptions) {
+}: CreateVmOptions = {}) {
   const emulator = new V86({
     wasm_path: `${dirname(require.resolve('v86'))}/v86.wasm`,
     bios: { url: join(import.meta.dirname, './images/seabios.bin') },
@@ -109,7 +109,9 @@ export async function createVm({
   }
 
   await waitForSequence(promptSequence);
-  await executeCommand(`ip addr add ${ip} dev eth0`);
+  if (ip) {
+    await executeCommand(`ip addr add ${ip} dev eth0`);
+  }
   await executeCommand('ip link set eth0 up');
 
   const net = createV86NetworkStream(emulator);

--- a/packages/v86/tsconfig.json
+++ b/packages/v86/tsconfig.json
@@ -6,6 +6,7 @@
     "paths": {
       "tcpip": ["../tcpip/src/index.js"],
       "tcpip/types": ["../tcpip/src/types.js"],
+      "@tcpip/dhcp": ["../dhcp/src/index.js"],
       "@tcpip/dns": ["../dns/src/index.js"],
       "@tcpip/wire": ["../wire/src/index.js"]
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
 
   packages/v86:
     devDependencies:
+      '@tcpip/dhcp':
+        specifier: workspace:*
+        version: link:../dhcp
       '@tcpip/wire':
         specifier: workspace:*
         version: link:../wire


### PR DESCRIPTION
Brings `@tcpip/dhcp` to a state where we can document it and use it as a primitive elsewhere. It doesn't have exhaustive DHCP support, but includes the core features to make it usable. Includes 3 layers of tests:
1. Unit tests for lease allocation, offer reservation, renewals, releases, conflicts, NAKs, and exhausted ranges
2. `tcpip` tests that execute the real UDP/broadcast path instead of only mocking server calls
3. v86 integration tests that prove VMs can obtain an IP address and DNS server dynamically via `@tcpip/dhcp`