### PR TITLE
Add HTTP support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,26 @@ jobs:
           rm -f "$NPM_VIEW_STDERR"
           pnpm publish --access public --no-git-checks --ignore-scripts --provenance
 
+      - name: Publish @tcpip/http
+        if: ${{ steps.release.outputs['packages/http--release_created'] == 'true' }}
+        working-directory: packages/http
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          NPM_VIEW_STDERR=$(mktemp)
+          EXISTING=$(npm view "@tcpip/http@$VERSION" version 2>"$NPM_VIEW_STDERR") || STATUS=$?
+          if [ -n "$EXISTING" ]; then
+            echo "@tcpip/http@$VERSION is already published, skipping."
+            rm -f "$NPM_VIEW_STDERR"
+            exit 0
+          elif [ "${STATUS:-0}" -ne 0 ] && ! grep -qiE 'E404|not found' "$NPM_VIEW_STDERR"; then
+            cat "$NPM_VIEW_STDERR"
+            rm -f "$NPM_VIEW_STDERR"
+            exit 1
+          fi
+          rm -f "$NPM_VIEW_STDERR"
+          pnpm publish --access public --no-git-checks --ignore-scripts --provenance
+
       - name: Publish @tcpip/dhcp
         if: ${{ steps.release.outputs['packages/dhcp--release_created'] == 'true' }}
         working-directory: packages/dhcp

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,7 @@
 {
   "packages/tcpip": "0.3.4",
   "packages/wire": "0.1.3",
+  "packages/http": "0.0.0",
   "packages/dns": "0.2.2",
   "packages/dhcp": "0.2.3",
   "packages/v86": "0.2.2"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - **Bridge:** Create a virtual switch/LAN by [`bridging`](#bridge-interface) multiple interfaces together
 - **TCP API:** Establish TCP connections over the virtual network stack using [clients](#connecttcp) and [servers](#listentcp)
 - **UDP API:** Send and receive UDP datagrams over the virtual network stack using [sockets](#openudp)
+- **L4 APIs:** Higher level APIs are available ([`@tcpip/http`](packages/http), [`@tcpip/dns`](packages/dns), [`@tcpip/dhcp`](packages/dhcp))
 - **Cross platform**: Built on web standard APIs (`ReadableStream`, `WritableStream`, etc)
 - **Lightweight:** Less than 100KB
 - **Fast:** Over 500Mbps between stacks
@@ -556,7 +557,7 @@ As with any web stream, you can pipe data through a transform stream:
 
 ```ts
 const decompressedStream = connection.readable.pipeThrough(
-  new DecompressionStream('gzip')
+  new DecompressionStream('gzip'),
 );
 ```
 
@@ -643,7 +644,7 @@ for await (const datagram of udpSocket) {
   console.log(
     datagram.host,
     datagram.port,
-    new TextDecoder().decode(datagram.data)
+    new TextDecoder().decode(datagram.data),
   );
 }
 ```
@@ -731,7 +732,7 @@ If you leave the name server as the default (`127.0.0.1:53`) and don't run your 
 
 ### DNS APIs
 
-DNS APIs are available via a standalone package `@tcpip/dns`. This package provides both `serve()` and `lookup()` functions that you can use to serve DNS records or resolve hostnames. It's built on top of the tcpip.js UDP API.
+DNS APIs are available via a standalone package `@tcpip/dns`. This package provides both `serve()` and `lookup()` functions that you can use to serve DNS records or resolve hostnames. It's built on top of the tcpip.js [UDP API](#udp-api).
 
 Start by calling `createDns()` to create `lookup()` and `serve()` functions for your stack:
 
@@ -800,6 +801,12 @@ await serve({
 });
 ```
 
+## HTTP API
+
+An HTTP API is available via a standalone package `@tcpip/http`. It adds HTTP/1.1 client and server support built on top of the tcpip.js [TCP API](#tcp-api). It exposes a Fetch-compatible API for virtual networks: a `fetch` function for outbound requests and a `serve` function for handling inbound requests. Both work with standard `Request`, `Response`, and `Headers` objects, and support streaming request and response bodies.
+
+For more details, see the [HTTP package README](packages/http/README.md).
+
 ## Frameworks/bundlers
 
 Some frameworks require additional configuration to correctly load WASM files (which `tcpip.js` depends on). Here are some common frameworks and how to configure them:
@@ -823,9 +830,7 @@ _Background:_ Vite optimizes dependencies during development to improve build ti
 
 ## Future plans
 
-- [ ] HTTP API
 - [ ] ICMP (ping) API
-- [ ] DHCP API
 - [ ] mDNS API
 - [ ] Hosts file
 - [ ] Experimental Wireguard interface

--- a/packages/http/.gitignore
+++ b/packages/http/.gitignore
@@ -1,0 +1,4 @@
+llhttp/
+*.o
+*.a
+*.wasm

--- a/packages/http/Makefile
+++ b/packages/http/Makefile
@@ -1,0 +1,54 @@
+CC ?= clang
+TARGET = wasm32-wasi
+CFLAGS = -Oz -Wall -std=c11
+LDFLAGS = -Wl,--gc-sections,--strip-all,--export=malloc,--export=free,--allow-undefined -mexec-model=reactor
+
+LLHTTP_REPO = https://github.com/nodejs/llhttp
+LLHTTP_TAG = release/v9.4.1
+LLHTTP_DIR = llhttp
+LLHTTP_STAMP = $(LLHTTP_DIR)/.stamp
+LLHTTP_INCLUDE = $(LLHTTP_DIR)/include
+HTTP_PARSER_SRC_FILES = wasm/http_parser.c
+LLHTTP_SRC_FILES = \
+	$(LLHTTP_DIR)/src/llhttp.c \
+	$(LLHTTP_DIR)/src/api.c \
+	$(LLHTTP_DIR)/src/http.c
+
+HTTP_PARSER_OBJ_FILES = $(HTTP_PARSER_SRC_FILES:.c=.o)
+LLHTTP_OBJ_FILES = $(LLHTTP_SRC_FILES:.c=.o)
+LLHTTP_LIB = $(LLHTTP_DIR)/llhttp.a
+OUT = http_parser.wasm
+
+.DEFAULT_GOAL := build
+
+wasm/%.o: wasm/%.c | $(LLHTTP_STAMP)
+	$(CC) --target=$(TARGET) -I$(LLHTTP_INCLUDE) $(CFLAGS) -c $< -o $@
+
+$(LLHTTP_DIR)/%.o: $(LLHTTP_DIR)/%.c | $(LLHTTP_STAMP)
+	$(CC) --target=$(TARGET) -I$(LLHTTP_INCLUDE) $(CFLAGS) -c $< -o $@
+
+$(LLHTTP_STAMP):
+	git clone --depth 1 --branch $(LLHTTP_TAG) $(LLHTTP_REPO) $(LLHTTP_DIR)
+	touch $(LLHTTP_STAMP)
+	$(MAKE) $(MAKECMDGOALS)
+
+$(LLHTTP_LIB): $(LLHTTP_STAMP) $(LLHTTP_OBJ_FILES)
+	$(AR) rcs $(LLHTTP_LIB) $(LLHTTP_OBJ_FILES)
+
+$(OUT): $(HTTP_PARSER_OBJ_FILES) $(LLHTTP_LIB)
+	$(CC) --target=$(TARGET) $(LDFLAGS) -o $(OUT) $(HTTP_PARSER_OBJ_FILES) $(LLHTTP_LIB)
+
+build: $(OUT)
+
+clean:
+	rm -f $(OUT)
+	rm -f $(HTTP_PARSER_OBJ_FILES)
+
+clean-vendor:
+	rm -f $(LLHTTP_OBJ_FILES)
+	rm -f $(LLHTTP_LIB)
+
+clean-all: clean clean-vendor
+	rm -rf $(LLHTTP_DIR)
+
+.PHONY: build clean clean-vendor clean-all

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -1,0 +1,105 @@
+# @tcpip/http
+
+> HTTP client and server for tcpip.js virtual networks.
+
+`@tcpip/http` adds HTTP/1.1 client and server support on top of the [TCP streams](../../README.md#tcp-api) provided by `tcpip`. It exposes a Fetch-compatible API for virtual networks: a `fetch` function for outbound requests and a `serve` function for handling inbound requests. Both work with standard `Request`, `Response`, and `Headers` objects, and support streaming request and response bodies.
+
+## How does it work?
+
+`@tcpip/http` is built on top of [llhttp](https://github.com/nodejs/llhttp), the C HTTP parser used by Node.js, compiled to a small WASM module. `llhttp` handles the nuanced HTTP grammar and framing rules, while `@tcpip/http` provides the virtual TCP integration, Fetch objects, and stream plumbing.
+
+## Installation
+
+```shell
+npm i tcpip @tcpip/http
+```
+
+## Usage
+
+```ts
+import { createStack } from 'tcpip';
+import { createHttp } from '@tcpip/http';
+
+const stack = await createStack();
+const { fetch, serve } = await createHttp(stack);
+
+await serve(async (request) => {
+  return new Response('hello from tcpip.js');
+});
+
+const response = await fetch('http://127.0.0.1/hello');
+console.log(await response.text());
+// hello from tcpip.js
+```
+
+Practically, `@tcpip/http` is most useful as a tool to communicate with VMs like v86 over HTTP.
+
+## Custom fetch for SDKs
+
+Many SDKs accept a custom `fetch` option so callers can choose their own transport. `createHttp(stack)` returns a fetch-compatible function for exactly that use case: it accepts the standard `fetch(input, init)` arguments, sends the request over the tcpip.js virtual network, and returns a standard `Response`.
+
+```ts
+const sdk = new SomeSdk({
+  fetch,
+});
+```
+
+This means you can use existing HTTP-based SDKs to interact with services running on your tcpip.js virtual network (like a v86 VM), without needing to modify the SDK or use a separate proxy.
+
+## API
+
+```ts
+const { fetch, serve } = await createHttp(stack);
+```
+
+`fetch(input, init)` is compatible with `typeof globalThis.fetch` for plain `http:` URLs.
+
+When sending a request body in browsers, prefer the `fetch(url, init)` form instead of pre-constructing a `Request` object:
+
+```ts
+await fetch('http://127.0.0.1/form', {
+  method: 'POST',
+  body: new URLSearchParams({ name: 'tcpip' }),
+});
+```
+
+Some [browsers](https://developer.mozilla.org/en-US/docs/Web/API/Request/body#browser_compatibility) (i.e. Firefox), do not expose `Request.body` for a pre-constructed `Request`. If you pass a `Request` object to `fetch` that already contains a body, `@tcpip/http` cannot recover the original bytes for these browsers. Passing the body through `init.body` lets `@tcpip/http` serialize it directly, and also allows it to send `Content-Length` for known-size bodies like strings, `URLSearchParams`, `Blob`, `ArrayBuffer`, and typed arrays. Unknown-size streams are sent with `Transfer-Encoding: chunked`.
+
+`serve(handler)` listens on virtual port `80` by default on all interfaces.
+
+```ts
+await serve((request) => new Response('ok'));
+```
+
+`serve(options, handler)` listens on an explicit virtual host and/or port.
+
+```ts
+await serve({ host: '127.0.0.1', port: 8080 }, (request) => new Response('ok'));
+```
+
+`serve({ ...options, handler })` is also supported.
+
+```ts
+await serve({
+  host: '127.0.0.1',
+  port: 8080,
+  handler: (request) => new Response('ok'),
+});
+```
+
+## Scope
+
+Supported:
+
+- HTTP/1.1 over `tcpip` TCP streams
+- plain `http:` URLs
+- standard `Request`, `Response`, and `Headers` objects
+- streaming request and response bodies
+- `Content-Length` parsing and chunked transfer encoding
+
+Not supported:
+
+- `https:` URLs
+- browser CORS, cache, cookies, or credential policy
+- HTTP/2 or HTTP/3
+- CONNECT, upgrades, trailers, compression, connection pooling, or pipelining

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@tcpip/http",
+  "version": "0.0.0",
+  "description": "HTTP client and server built on tcpip.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chipmk/tcpip.js.git",
+    "directory": "packages/http"
+  },
+  "main": "dist/index.cjs",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "build": "pnpm run build:js && pnpm run build:wasm",
+    "build:js": "tsup --clean",
+    "build:wasm": "pnpm run make build",
+    "clean": "rm -rf dist",
+    "make": "CC='docker compose -f ../tcpip/docker-compose.yml run --rm wasi-sdk /opt/wasi-sdk/bin/clang' AR='docker compose -f ../tcpip/docker-compose.yml run --rm wasi-sdk /opt/wasi-sdk/bin/ar' make",
+    "test": "vitest",
+    "prepublishOnly": "pnpm run build"
+  },
+  "files": ["dist/**/*", "http_parser.wasm"],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.cjs"
+    }
+  },
+  "devDependencies": {
+    "@bjorn3/browser_wasi_shim": "^0.3.0",
+    "@playwright/test": "catalog:",
+    "@total-typescript/tsconfig": "catalog:",
+    "@types/node": "catalog:",
+    "@vitest/browser": "catalog:",
+    "tcpip": "workspace:*",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/http/src/errors.ts
+++ b/packages/http/src/errors.ts
@@ -1,0 +1,10 @@
+export class HttpProtocolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'HttpProtocolError';
+  }
+}
+
+export function unsupportedProtocol(protocol: string) {
+  return new TypeError(`unsupported protocol: ${protocol}`);
+}

--- a/packages/http/src/fetch.test.ts
+++ b/packages/http/src/fetch.test.ts
@@ -1,0 +1,203 @@
+import { createStack } from 'tcpip';
+import type { NetworkStack, TcpConnection } from 'tcpip/types';
+import { describe, expect, test } from 'vitest';
+import { createHttp } from './index.js';
+
+async function nextValue<T>(iterator: AsyncIterable<T>) {
+  const { value } = await iterator[Symbol.asyncIterator]().next();
+  return value!;
+}
+
+async function readUntil(connection: TcpConnection, expected: string) {
+  const decoder = new TextDecoder();
+  const reader = connection.readable.getReader();
+  let text = '';
+
+  try {
+    while (!text.includes(expected)) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return text;
+}
+
+function trackConnectionClose(
+  stack: NetworkStack,
+  connection: TcpConnection
+): NetworkStack {
+  let closeCount = 0;
+  const trackedConnection = {
+    ...connection,
+    async close() {
+      closeCount++;
+      await connection.close();
+    },
+    [Symbol.asyncIterator]: () => connection[Symbol.asyncIterator](),
+  } satisfies TcpConnection;
+
+  return {
+    ...stack,
+    connectTcp: async () => trackedConnection,
+    get closeCount() {
+      return closeCount;
+    },
+  } as NetworkStack & { readonly closeCount: number };
+}
+
+describe('fetch', () => {
+  test('fetches from an HTTP server on loopback', async () => {
+    const stack = await createStack();
+    const listener = await stack.listenTcp({
+      host: '127.0.0.1',
+      port: 8081,
+    });
+
+    const serverDone = (async () => {
+      const connection = await nextValue(listener);
+      const reader = connection.readable.getReader();
+      await reader.read();
+      reader.releaseLock();
+      const writer = connection.writable.getWriter();
+      await writer.write(
+        new TextEncoder().encode(
+          'HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\ncontent-length: 5\r\nconnection: close\r\n\r\nhello'
+        )
+      );
+      writer.releaseLock();
+      return connection;
+    })();
+
+    const { fetch } = await createHttp(stack);
+    const response = await fetch('http://127.0.0.1:8081/test');
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('text/plain');
+    await expect(response.text()).resolves.toBe('hello');
+
+    const serverConnection = await serverDone;
+    await serverConnection.close();
+  });
+
+  test('sends content length for known init bodies', async () => {
+    const stack = await createStack();
+    const listener = await stack.listenTcp({
+      host: '127.0.0.1',
+      port: 8087,
+    });
+
+    const serverDone = (async () => {
+      const connection = await nextValue(listener);
+      const request = await readUntil(connection, '\r\n\r\nname=tcpip');
+      const writer = connection.writable.getWriter();
+      await writer.write(
+        new TextEncoder().encode(
+          'HTTP/1.1 204 No Content\r\ncontent-length: 0\r\nconnection: close\r\n\r\n'
+        )
+      );
+      writer.releaseLock();
+      return { connection, request };
+    })();
+
+    const { fetch } = await createHttp(stack);
+    const response = await fetch('http://127.0.0.1:8087/form', {
+      method: 'POST',
+      body: 'name=tcpip',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+    });
+
+    expect(response.status).toBe(204);
+
+    const { connection, request } = await serverDone;
+    expect(request).toContain('content-length: 10\r\n');
+    expect(request).not.toContain('transfer-encoding: chunked');
+    expect(request.endsWith('\r\n\r\nname=tcpip')).toBe(true);
+    await connection.close();
+  });
+
+  test('closes the TCP connection after the response body is consumed', async () => {
+    const stack = await createStack();
+    const listener = await stack.listenTcp({
+      host: '127.0.0.1',
+      port: 8086,
+    });
+    const serverConnectionPromise = nextValue(listener);
+
+    const rawConnection = await stack.connectTcp({
+      host: '127.0.0.1',
+      port: 8086,
+    });
+    const trackedStack = trackConnectionClose(
+      stack,
+      rawConnection
+    ) as NetworkStack & {
+      readonly closeCount: number;
+    };
+
+    const serverDone = (async () => {
+      const connection = await serverConnectionPromise;
+      const reader = connection.readable.getReader();
+      await reader.read();
+      reader.releaseLock();
+      const writer = connection.writable.getWriter();
+      await writer.write(
+        new TextEncoder().encode(
+          'HTTP/1.1 200 OK\r\ncontent-length: 5\r\nconnection: close\r\n\r\nhello'
+        )
+      );
+      writer.releaseLock();
+      return connection;
+    })();
+
+    const { fetch } = await createHttp(trackedStack);
+    const response = await fetch('http://127.0.0.1:8086/test');
+
+    expect(trackedStack.closeCount).toBe(0);
+    await expect(response.text()).resolves.toBe('hello');
+    expect(trackedStack.closeCount).toBe(1);
+
+    const serverConnection = await serverDone;
+    await serverConnection.close();
+  });
+
+  test('rejects https URLs until TLS exists', async () => {
+    const stack = await createStack();
+    const { fetch } = await createHttp(stack);
+
+    await expect(fetch('https://example.com/')).rejects.toThrow(
+      'unsupported protocol: https:'
+    );
+  });
+
+  test('fetch can call serve on the same stack', async () => {
+    const stack = await createStack();
+    const { fetch, serve } = await createHttp(stack);
+
+    await serve({ host: '127.0.0.1', port: 8084 }, async (request) => {
+      return Response.json({
+        method: request.method,
+        path: new URL(request.url).pathname,
+        body: await request.text(),
+      });
+    });
+
+    const response = await fetch('http://127.0.0.1:8084/items', {
+      method: 'POST',
+      body: 'abc',
+    });
+
+    await expect(response.json()).resolves.toStrictEqual({
+      method: 'POST',
+      path: '/items',
+      body: 'abc',
+    });
+  });
+});

--- a/packages/http/src/fetch.ts
+++ b/packages/http/src/fetch.ts
@@ -1,0 +1,189 @@
+import type { NetworkStack } from 'tcpip/types';
+import { unsupportedProtocol } from './errors.js';
+import { HttpParser } from './parser.js';
+import {
+  type SerializableHttpBody,
+  serializeHttpRequest,
+  statusAllowsBody,
+} from './serialize.js';
+import type { HttpFetch, HttpParserRuntime } from './types.js';
+
+function bytesToStream(bytes: Uint8Array) {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+function knownBytesToBody(bytes: Uint8Array): SerializableHttpBody {
+  return {
+    stream: bytesToStream(bytes),
+    length: bytes.length,
+  };
+}
+
+function bodyToSerializableBody(
+  body: BodyInit | null | undefined
+): SerializableHttpBody {
+  if (body === undefined || body === null) {
+    return null;
+  }
+
+  if (body instanceof ReadableStream) {
+    return body as ReadableStream<Uint8Array>;
+  }
+
+  if (typeof body === 'string') {
+    return knownBytesToBody(new TextEncoder().encode(body));
+  }
+
+  if (body instanceof URLSearchParams) {
+    return knownBytesToBody(new TextEncoder().encode(body.toString()));
+  }
+
+  if (body instanceof Blob) {
+    return {
+      stream: body.stream() as ReadableStream<Uint8Array>,
+      length: body.size,
+    };
+  }
+
+  if (body instanceof ArrayBuffer) {
+    return knownBytesToBody(new Uint8Array(body));
+  }
+
+  if (ArrayBuffer.isView(body)) {
+    return knownBytesToBody(
+      new Uint8Array(body.buffer, body.byteOffset, body.byteLength)
+    );
+  }
+
+  return null;
+}
+
+function closeConnectionWithBody(
+  body: ReadableStream<Uint8Array>,
+  close: () => Promise<void>
+) {
+  const reader = body.getReader();
+  const closeConnection = () => {
+    close().catch((error) => {
+      console.error('error closing http connection:', error);
+    });
+  };
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) {
+        reader.releaseLock();
+        controller.close();
+        closeConnection();
+        return;
+      }
+
+      controller.enqueue(value);
+    },
+    async cancel() {
+      reader.releaseLock();
+      closeConnection();
+    },
+  });
+}
+
+function canHaveResponseBody(request: Request, status: number) {
+  return request.method !== 'HEAD' && statusAllowsBody(status);
+}
+
+async function feedParser(
+  readable: ReadableStream<Uint8Array>,
+  parser: HttpParser
+) {
+  const reader = readable.getReader();
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        parser.finish();
+        break;
+      }
+      parser.write(value);
+    }
+  } catch (error) {
+    if (
+      !(error instanceof Error && error.message === 'tcp connection closed')
+    ) {
+      throw error;
+    }
+    parser.finish();
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export function createFetch(
+  stack: NetworkStack,
+  parserRuntime: HttpParserRuntime
+): HttpFetch {
+  return async (input, init) => {
+    const request = new Request(input, init);
+    const body =
+      init?.body !== undefined
+        ? bodyToSerializableBody(init.body)
+        : request.body;
+    const url = new URL(request.url);
+
+    if (url.protocol !== 'http:') {
+      throw unsupportedProtocol(url.protocol);
+    }
+
+    const connection = await stack.connectTcp({
+      host: url.hostname,
+      port: Number(url.port || 80),
+    });
+
+    const parser = new HttpParser(parserRuntime, 'response');
+    const responsePromise = parser.nextMessage();
+
+    const requestWrite = serializeHttpRequest(request, body).pipeTo(
+      connection.writable,
+      { preventClose: true }
+    );
+    const responseRead = feedParser(connection.readable, parser);
+
+    await requestWrite;
+
+    const message = await responsePromise;
+
+    if (message.type !== 'response') {
+      throw new Error('expected http response');
+    }
+
+    responseRead.catch((error) => {
+      console.error('error reading http response:', error);
+    });
+
+    if (!canHaveResponseBody(request, message.statusCode)) {
+      connection.close().catch((error) => {
+        console.error('error closing http connection:', error);
+      });
+      return new Response(null, {
+        status: message.statusCode,
+        statusText: message.statusText,
+        headers: message.headers,
+      });
+    }
+
+    return new Response(
+      closeConnectionWithBody(message.body, () => connection.close()),
+      {
+        status: message.statusCode,
+        statusText: message.statusText,
+        headers: message.headers,
+      }
+    );
+  };
+}

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -1,0 +1,82 @@
+import type { NetworkStack } from 'tcpip/types';
+import { createFetch } from './fetch.js';
+import { serveHttp } from './serve.js';
+import type {
+  CreateHttpOptions,
+  HttpApi,
+  HttpRequestHandler,
+  ServeHandlerOptions,
+  ServeOptions,
+} from './types.js';
+import { LlhttpBindings } from './wasm/bindings.js';
+
+export type {
+  CreateHttp,
+  CreateHttpOptions,
+  HttpApi,
+  HttpFetch,
+  HttpRequestHandler,
+  HttpServer,
+  ServeHandlerOptions,
+  ServeOptions,
+} from './types.js';
+
+const defaultServeOptions: ServeOptions = {
+  port: 80,
+};
+
+function normalizeServeArgs(
+  first: HttpRequestHandler | ServeOptions | ServeHandlerOptions,
+  second?: HttpRequestHandler
+) {
+  if (typeof first === 'function') {
+    return {
+      options: defaultServeOptions,
+      handler: first,
+    };
+  }
+
+  if ('handler' in first) {
+    const { handler, ...options } = first;
+    return {
+      options: {
+        ...defaultServeOptions,
+        ...options,
+      },
+      handler,
+    };
+  }
+
+  if (!second) {
+    throw new TypeError('serve options require a handler');
+  }
+
+  return {
+    options: first,
+    handler: second,
+  };
+}
+
+export async function createHttp(
+  stack: NetworkStack,
+  options: CreateHttpOptions = {}
+): Promise<HttpApi> {
+  const parser = options.parser ?? new LlhttpBindings();
+  await parser.ready?.();
+
+  const serve = (async (
+    first: HttpRequestHandler | ServeOptions | ServeHandlerOptions,
+    second?: HttpRequestHandler
+  ) => {
+    const { options: serveOptions, handler } = normalizeServeArgs(
+      first,
+      second
+    );
+    return serveHttp(stack, parser, serveOptions, handler);
+  }) satisfies HttpApi['serve'];
+
+  return {
+    fetch: createFetch(stack, parser),
+    serve,
+  };
+}

--- a/packages/http/src/parser.test.ts
+++ b/packages/http/src/parser.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from 'vitest';
+import { HttpParser } from './parser.js';
+import type {
+  HttpHeadersEvent,
+  HttpParserCallbacks,
+  HttpParserRuntime,
+  HttpParserType,
+} from './types.js';
+
+class TrackingRuntime implements HttpParserRuntime {
+  callbacks = new Map<number, HttpParserCallbacks>();
+  freed: number[] = [];
+  nextHandle = 1;
+
+  createParser(_type: HttpParserType, callbacks: HttpParserCallbacks) {
+    const handle = this.nextHandle++;
+    this.callbacks.set(handle, callbacks);
+    return handle;
+  }
+
+  executeParser(_handle: number, _chunk: Uint8Array) {}
+
+  finishParser(_handle: number) {}
+
+  freeParser(handle: number) {
+    this.freed.push(handle);
+    this.callbacks.delete(handle);
+  }
+}
+
+const responseHeaders = {
+  parserType: 'response',
+  statusCode: 200,
+  statusText: 'OK',
+  httpMajor: 1,
+  httpMinor: 1,
+  headers: [],
+  shouldKeepAlive: false,
+  upgrade: false,
+} satisfies HttpHeadersEvent;
+
+describe('HttpParser', () => {
+  test('frees its runtime parser handle when a message completes', async () => {
+    const runtime = new TrackingRuntime();
+    const parser = new HttpParser(runtime, 'response');
+    const messagePromise = parser.nextMessage();
+    const callbacks = runtime.callbacks.get(parser.handle)!;
+
+    callbacks.headers(responseHeaders);
+    callbacks.body(new TextEncoder().encode('ok'));
+    callbacks.complete();
+
+    const message = await messagePromise;
+    await expect(message.body.getReader().read()).resolves.toMatchObject({
+      done: false,
+      value: new TextEncoder().encode('ok'),
+    });
+    await Promise.resolve();
+    expect(runtime.freed).toEqual([parser.handle]);
+    expect(runtime.callbacks.has(parser.handle)).toBe(false);
+
+    parser.close();
+    expect(runtime.freed).toEqual([parser.handle]);
+  });
+
+  test('frees its runtime parser handle when parsing errors', async () => {
+    const runtime = new TrackingRuntime();
+    const parser = new HttpParser(runtime, 'response');
+    const messagePromise = parser.nextMessage();
+    const callbacks = runtime.callbacks.get(parser.handle)!;
+
+    callbacks.error(new Error('boom'));
+
+    await expect(messagePromise).rejects.toThrow('boom');
+    await Promise.resolve();
+    expect(runtime.freed).toEqual([parser.handle]);
+    expect(runtime.callbacks.has(parser.handle)).toBe(false);
+  });
+
+  test('rejects request header events missing method or url', async () => {
+    const runtime = new TrackingRuntime();
+    const parser = new HttpParser(runtime, 'request');
+    const messagePromise = parser.nextMessage();
+    const callbacks = runtime.callbacks.get(parser.handle)!;
+
+    callbacks.headers({
+      parserType: 'request',
+      httpMajor: 1,
+      httpMinor: 1,
+      headers: [],
+      shouldKeepAlive: false,
+      upgrade: false,
+    });
+
+    await expect(messagePromise).rejects.toThrow(
+      'http request is missing method'
+    );
+  });
+
+  test('rejects response header events missing status code', async () => {
+    const runtime = new TrackingRuntime();
+    const parser = new HttpParser(runtime, 'response');
+    const messagePromise = parser.nextMessage();
+    const callbacks = runtime.callbacks.get(parser.handle)!;
+
+    callbacks.headers({
+      parserType: 'response',
+      statusText: '',
+      httpMajor: 1,
+      httpMinor: 1,
+      headers: [],
+      shouldKeepAlive: false,
+      upgrade: false,
+    });
+
+    await expect(messagePromise).rejects.toThrow(
+      'http response is missing status code'
+    );
+  });
+});

--- a/packages/http/src/parser.ts
+++ b/packages/http/src/parser.ts
@@ -1,0 +1,164 @@
+import type {
+  HttpHeadersEvent,
+  HttpParserRuntime,
+  HttpParserType,
+  ParsedHttpMessage,
+} from './types.js';
+
+type PendingMessage = {
+  resolve(message: ParsedHttpMessage): void;
+  reject(error: Error): void;
+};
+
+export class HttpParser {
+  readonly handle: number;
+
+  #runtime: HttpParserRuntime;
+  #messages: ParsedHttpMessage[] = [];
+  #pendingMessages: PendingMessage[] = [];
+  #currentBodyController?: ReadableStreamDefaultController<Uint8Array>;
+  #freed = false;
+  #closed = false;
+
+  get closed() {
+    return this.#closed;
+  }
+
+  constructor(runtime: HttpParserRuntime, type: HttpParserType) {
+    this.#runtime = runtime;
+    this.handle = runtime.createParser(type, {
+      headers: (event) => this.#onHeaders(event),
+      body: (chunk) => this.#onBody(chunk),
+      complete: () => this.#onComplete(),
+      error: (error) => this.#onError(error),
+    });
+  }
+
+  write(chunk: Uint8Array) {
+    if (this.#closed) {
+      throw new Error('http parser is closed');
+    }
+
+    this.#runtime.executeParser(this.handle, chunk);
+  }
+
+  finish() {
+    if (!this.#closed) {
+      this.#runtime.finishParser(this.handle);
+    }
+  }
+
+  close() {
+    if (this.#closed) {
+      return;
+    }
+
+    this.#closed = true;
+    this.#free();
+  }
+
+  #free() {
+    if (this.#freed) {
+      return;
+    }
+
+    this.#freed = true;
+    this.#runtime.freeParser(this.handle);
+  }
+
+  #freeSoon() {
+    this.#closed = true;
+    queueMicrotask(() => this.#free());
+  }
+
+  nextMessage() {
+    const message = this.#messages.shift();
+    if (message) {
+      return Promise.resolve(message);
+    }
+
+    return new Promise<ParsedHttpMessage>((resolve, reject) => {
+      this.#pendingMessages.push({ resolve, reject });
+    });
+  }
+
+  #onHeaders(event: HttpHeadersEvent) {
+    const body = new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        this.#currentBodyController = controller;
+      },
+    });
+
+    const headers = new Headers(event.headers);
+
+    let message: ParsedHttpMessage;
+    if (event.parserType === 'request') {
+      if (!event.method) {
+        this.#onError(new Error('http request is missing method'));
+        return;
+      }
+      if (!event.url) {
+        this.#onError(new Error('http request is missing url'));
+        return;
+      }
+
+      message = {
+        type: 'request',
+        method: event.method,
+        url: event.url,
+        httpMajor: event.httpMajor,
+        httpMinor: event.httpMinor,
+        headers,
+        body,
+        shouldKeepAlive: event.shouldKeepAlive,
+        upgrade: event.upgrade,
+      };
+    } else {
+      if (event.statusCode === undefined) {
+        this.#onError(new Error('http response is missing status code'));
+        return;
+      }
+
+      message = {
+        type: 'response',
+        statusCode: event.statusCode,
+        statusText: event.statusText ?? '',
+        httpMajor: event.httpMajor,
+        httpMinor: event.httpMinor,
+        headers,
+        body,
+        shouldKeepAlive: event.shouldKeepAlive,
+        upgrade: event.upgrade,
+      };
+    }
+
+    const pending = this.#pendingMessages.shift();
+    if (pending) {
+      pending.resolve(message);
+    } else {
+      this.#messages.push(message);
+    }
+  }
+
+  #onBody(chunk: Uint8Array) {
+    this.#currentBodyController?.enqueue(chunk);
+  }
+
+  #onComplete() {
+    this.#currentBodyController?.close();
+    this.#currentBodyController = undefined;
+    this.#freeSoon();
+  }
+
+  #onError(error: Error) {
+    this.#currentBodyController?.error(error);
+    this.#currentBodyController = undefined;
+
+    for (const pending of this.#pendingMessages) {
+      pending.reject(error);
+    }
+
+    this.#pendingMessages = [];
+    this.#freeSoon();
+  }
+}

--- a/packages/http/src/serialize.test.ts
+++ b/packages/http/src/serialize.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, test } from 'vitest';
+import { serializeHttpRequest, serializeHttpResponse } from './serialize.js';
+
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+
+function requestHasReadableBody(request: Request) {
+  return request.body instanceof ReadableStream;
+}
+
+function streamFromText(text: string) {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+}
+
+async function readAll(readable: ReadableStream<Uint8Array>) {
+  const chunks: Uint8Array[] = [];
+  const reader = readable.getReader();
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    chunks.push(value);
+  }
+
+  const length = chunks.reduce((total, chunk) => total + chunk.length, 0);
+  const result = new Uint8Array(length);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return decoder.decode(result);
+}
+
+describe('serializeHttpRequest', () => {
+  test('serializes a GET request with host and connection close', async () => {
+    const request = new Request('http://example.com/path?q=1');
+
+    await expect(readAll(serializeHttpRequest(request))).resolves.toBe(
+      'GET /path?q=1 HTTP/1.1\r\nhost: example.com\r\nconnection: close\r\n\r\n'
+    );
+  });
+
+  test('serializes root targets with non-default and IPv6 hosts', async () => {
+    const withPort = new Request('http://example.com:8080/');
+    const ipv6 = new Request('http://[2001:db8::1]:8080/');
+
+    await expect(readAll(serializeHttpRequest(withPort))).resolves.toBe(
+      'GET / HTTP/1.1\r\nhost: example.com:8080\r\nconnection: close\r\n\r\n'
+    );
+    await expect(readAll(serializeHttpRequest(ipv6))).resolves.toBe(
+      'GET / HTTP/1.1\r\nhost: [2001:db8::1]:8080\r\nconnection: close\r\n\r\n'
+    );
+  });
+
+  test('preserves encoded path and query bytes in request target', async () => {
+    const request = new Request('http://example.com/a%20b?q=x%20y');
+
+    await expect(readAll(serializeHttpRequest(request))).resolves.toBe(
+      'GET /a%20b?q=x%20y HTTP/1.1\r\nhost: example.com\r\nconnection: close\r\n\r\n'
+    );
+  });
+
+  test('serializes a POST request with content length when body size is known', async () => {
+    const body = 'name=tcpip';
+    const request = new Request('http://example.com/form', {
+      method: 'POST',
+      body,
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+    });
+
+    await expect(
+      readAll(
+        serializeHttpRequest(request, {
+          stream: request.body ?? streamFromText(body),
+          length: encoder.encode(body).length,
+        })
+      )
+    ).resolves.toBe(
+      'POST /form HTTP/1.1\r\ncontent-type: application/x-www-form-urlencoded\r\nhost: example.com\r\nconnection: close\r\ncontent-length: 10\r\n\r\nname=tcpip'
+    );
+  });
+
+  test('serializes URLSearchParams bodies with content length', async () => {
+    const body = new URLSearchParams([
+      ['name', 'tcpip'],
+      ['mode', 'virtual network'],
+    ]);
+    const text = body.toString();
+    const request = new Request('http://example.com/form', {
+      method: 'POST',
+      body,
+    });
+
+    await expect(
+      readAll(
+        serializeHttpRequest(request, {
+          stream: request.body ?? streamFromText(text),
+          length: encoder.encode(text).length,
+        })
+      )
+    ).resolves.toBe(
+      'POST /form HTTP/1.1\r\ncontent-type: application/x-www-form-urlencoded;charset=UTF-8\r\nhost: example.com\r\nconnection: close\r\ncontent-length: 31\r\n\r\nname=tcpip&mode=virtual+network'
+    );
+  });
+
+  test('does not chunk known-size request bodies', async () => {
+    const request = new Request('http://example.com/upload', {
+      method: 'POST',
+      body: 'abc',
+      headers: {
+        'content-length': '3',
+      },
+    });
+
+    const serialized = await readAll(
+      serializeHttpRequest(request, {
+        stream: request.body ?? streamFromText('abc'),
+        length: 3,
+      })
+    );
+
+    expect(serialized).toMatch(
+      /^POST \/upload HTTP\/1\.1\r\n[\s\S]*\r\n\r\nabc$/
+    );
+    expect(serialized.match(/^content-length: 3$/gm)).toHaveLength(1);
+    expect(serialized).not.toContain('transfer-encoding: chunked');
+  });
+
+  test('serializes FormData bodies with multipart boundaries', async () => {
+    const form = new FormData();
+    form.set('name', 'tcpip');
+    form.set('file', new Blob(['hello']), 'hello.txt');
+
+    const request = new Request('http://example.com/upload', {
+      method: 'POST',
+      body: form,
+    });
+
+    const serialized = await readAll(serializeHttpRequest(request));
+
+    expect(serialized).toMatch(
+      /^POST \/upload HTTP\/1\.1\r\ncontent-type: multipart\/form-data; boundary=[^\r\n]+\r\nhost: example\.com\r\nconnection: close/
+    );
+    if (!requestHasReadableBody(request)) {
+      return;
+    }
+    expect(serialized).toContain('transfer-encoding: chunked\r\n\r\n');
+    expect(serialized).toContain('Content-Disposition: form-data; name="name"');
+    expect(serialized).toContain('tcpip');
+    expect(serialized).toContain(
+      'Content-Disposition: form-data; name="file"; filename="hello.txt"'
+    );
+    expect(serialized).toContain('Content-Type: application/octet-stream');
+    expect(serialized).toContain('hello');
+    expect(serialized.endsWith('\r\n0\r\n\r\n')).toBe(true);
+  });
+
+  test('streams request headers before reading the body', async () => {
+    let bodyController: ReadableStreamDefaultController<Uint8Array>;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        bodyController = controller;
+      },
+    });
+    const request = new Request('http://example.com/upload', {
+      method: 'POST',
+      body,
+      duplex: 'half',
+    } as RequestInit & { duplex: 'half' });
+    if (!requestHasReadableBody(request)) {
+      return;
+    }
+
+    const reader = serializeHttpRequest(request).getReader();
+    const first = await Promise.race([
+      reader.read(),
+      new Promise<'timeout'>((resolve) => setTimeout(resolve, 10, 'timeout')),
+    ]);
+
+    expect(first).not.toBe('timeout');
+    expect(
+      decoder.decode((first as ReadableStreamReadResult<Uint8Array>).value)
+    ).toBe(
+      'POST /upload HTTP/1.1\r\nhost: example.com\r\nconnection: close\r\ntransfer-encoding: chunked\r\n\r\n'
+    );
+
+    bodyController!.enqueue(encoder.encode('abc'));
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: encoder.encode('3\r\nabc\r\n'),
+    });
+
+    bodyController!.close();
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: encoder.encode('0\r\n\r\n'),
+    });
+    await expect(reader.read()).resolves.toStrictEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  test('serializes multiple request body chunks', async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('hello'));
+        controller.enqueue(encoder.encode(' world'));
+        controller.enqueue(new Uint8Array());
+        controller.close();
+      },
+    });
+    const request = new Request('http://example.com/upload', {
+      method: 'POST',
+      body,
+      duplex: 'half',
+    } as RequestInit & { duplex: 'half' });
+    if (!requestHasReadableBody(request)) {
+      return;
+    }
+
+    await expect(readAll(serializeHttpRequest(request))).resolves.toBe(
+      'POST /upload HTTP/1.1\r\nhost: example.com\r\nconnection: close\r\ntransfer-encoding: chunked\r\n\r\n5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n'
+    );
+  });
+});
+
+describe('serializeHttpResponse', () => {
+  test('serializes a text response with chunked transfer encoding', async () => {
+    const response = new Response('hello', {
+      status: 201,
+      statusText: 'Created',
+      headers: {
+        'x-test': 'yes',
+      },
+    });
+
+    await expect(readAll(serializeHttpResponse(response))).resolves.toBe(
+      'HTTP/1.1 201 Created\r\ncontent-type: text/plain;charset=UTF-8\r\nx-test: yes\r\nconnection: close\r\ntransfer-encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n'
+    );
+  });
+
+  test('streams response headers before reading the body', async () => {
+    let bodyController: ReadableStreamDefaultController<Uint8Array>;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        bodyController = controller;
+      },
+    });
+    const response = new Response(body);
+
+    const reader = serializeHttpResponse(response).getReader();
+    const first = await Promise.race([
+      reader.read(),
+      new Promise<'timeout'>((resolve) => setTimeout(resolve, 10, 'timeout')),
+    ]);
+
+    expect(first).not.toBe('timeout');
+    expect(
+      decoder.decode((first as ReadableStreamReadResult<Uint8Array>).value)
+    ).toBe(
+      'HTTP/1.1 200 OK\r\nconnection: close\r\ntransfer-encoding: chunked\r\n\r\n'
+    );
+
+    bodyController!.enqueue(encoder.encode('hello'));
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: encoder.encode('5\r\nhello\r\n'),
+    });
+
+    bodyController!.close();
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: encoder.encode('0\r\n\r\n'),
+    });
+    await expect(reader.read()).resolves.toStrictEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  test('omits body for 204 responses', async () => {
+    const response = new Response(null, { status: 204 });
+
+    await expect(readAll(serializeHttpResponse(response))).resolves.toBe(
+      'HTTP/1.1 204 No Content\r\nconnection: close\r\n\r\n'
+    );
+  });
+
+  test('omits body for 205 and 304 responses', async () => {
+    const reset = new Response(null, { status: 205 });
+    const notModified = new Response(null, { status: 304 });
+
+    await expect(readAll(serializeHttpResponse(reset))).resolves.toBe(
+      'HTTP/1.1 205 Reset Content\r\nconnection: close\r\n\r\n'
+    );
+    await expect(readAll(serializeHttpResponse(notModified))).resolves.toBe(
+      'HTTP/1.1 304 Not Modified\r\nconnection: close\r\n\r\n'
+    );
+  });
+
+  test('uses standard status text fallbacks', async () => {
+    await expect(
+      readAll(serializeHttpResponse(new Response(null, { status: 404 })))
+    ).resolves.toBe('HTTP/1.1 404 Not Found\r\nconnection: close\r\n\r\n');
+  });
+
+  test('uses unknown for unrecognized status text fallback', async () => {
+    await expect(
+      readAll(serializeHttpResponse(new Response(null, { status: 599 })))
+    ).resolves.toBe('HTTP/1.1 599 unknown\r\nconnection: close\r\n\r\n');
+  });
+
+  test('serializes multiple response body chunks', async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('hello'));
+        controller.enqueue(encoder.encode(' world'));
+        controller.enqueue(new Uint8Array());
+        controller.close();
+      },
+    });
+
+    await expect(
+      readAll(serializeHttpResponse(new Response(body)))
+    ).resolves.toBe(
+      'HTTP/1.1 200 OK\r\nconnection: close\r\ntransfer-encoding: chunked\r\n\r\n5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n'
+    );
+  });
+});

--- a/packages/http/src/serialize.ts
+++ b/packages/http/src/serialize.ts
@@ -1,0 +1,265 @@
+const encoder = new TextEncoder();
+
+export type SerializableHttpBody =
+  | ReadableStream<Uint8Array>
+  | {
+      stream: ReadableStream<Uint8Array>;
+      length?: number;
+    }
+  | null;
+
+const statusTexts = new Map<number, string>([
+  [200, 'OK'],
+  [201, 'Created'],
+  [202, 'Accepted'],
+  [203, 'Non-Authoritative Information'],
+  [204, 'No Content'],
+  [205, 'Reset Content'],
+  [206, 'Partial Content'],
+  [300, 'Multiple Choices'],
+  [301, 'Moved Permanently'],
+  [302, 'Found'],
+  [303, 'See Other'],
+  [304, 'Not Modified'],
+  [307, 'Temporary Redirect'],
+  [308, 'Permanent Redirect'],
+  [400, 'Bad Request'],
+  [401, 'Unauthorized'],
+  [403, 'Forbidden'],
+  [404, 'Not Found'],
+  [405, 'Method Not Allowed'],
+  [408, 'Request Timeout'],
+  [409, 'Conflict'],
+  [410, 'Gone'],
+  [413, 'Content Too Large'],
+  [414, 'URI Too Long'],
+  [415, 'Unsupported Media Type'],
+  [418, "I'm a Teapot"],
+  [422, 'Unprocessable Content'],
+  [425, 'Too Early'],
+  [429, 'Too Many Requests'],
+  [500, 'Internal Server Error'],
+  [501, 'Not Implemented'],
+  [502, 'Bad Gateway'],
+  [503, 'Service Unavailable'],
+  [504, 'Gateway Timeout'],
+]);
+
+function encode(text: string) {
+  return encoder.encode(text);
+}
+
+function hasHeader(headers: Headers, name: string) {
+  return headers.has(name);
+}
+
+function headerIncludes(headers: Headers, name: string, value: string) {
+  return (
+    headers
+      .get(name)
+      ?.split(',')
+      .some((part) => part.trim().toLowerCase() === value) ?? false
+  );
+}
+
+function appendHeaderLines(
+  lines: string[],
+  headers: Iterable<[string, string]>
+) {
+  for (const [name, value] of headers) {
+    lines.push(`${name}: ${value}`);
+  }
+}
+
+function bodyStream(body: SerializableHttpBody) {
+  if (!body) {
+    return null;
+  }
+  return body instanceof ReadableStream ? body : body.stream;
+}
+
+function bodyLength(body: SerializableHttpBody) {
+  if (!body || body instanceof ReadableStream) {
+    return undefined;
+  }
+  return body.length;
+}
+
+function requestHeaders(
+  request: Request,
+  hasBody: boolean,
+  knownLength?: number
+) {
+  const url = new URL(request.url);
+  const headers = new Headers(request.headers);
+  const lines: [string, string][] = [...headers];
+
+  if (!hasHeader(headers, 'host')) {
+    lines.push(['host', url.host]);
+  }
+
+  if (!hasHeader(headers, 'connection')) {
+    lines.push(['connection', 'close']);
+  }
+
+  if (
+    hasBody &&
+    !hasHeader(headers, 'content-length') &&
+    !hasHeader(headers, 'transfer-encoding')
+  ) {
+    if (knownLength !== undefined) {
+      lines.push(['content-length', String(knownLength)]);
+    } else {
+      lines.push(['transfer-encoding', 'chunked']);
+    }
+  }
+
+  return lines;
+}
+
+function responseHeaders(response: Response, hasBody: boolean) {
+  const headers = new Headers(response.headers);
+  const lines: [string, string][] = [...headers];
+
+  if (!hasHeader(headers, 'connection')) {
+    lines.push(['connection', 'close']);
+  }
+
+  if (
+    hasBody &&
+    !hasHeader(headers, 'content-length') &&
+    !hasHeader(headers, 'transfer-encoding')
+  ) {
+    lines.push(['transfer-encoding', 'chunked']);
+  }
+
+  return lines;
+}
+
+function statusText(response: Response) {
+  if (response.statusText) {
+    return response.statusText;
+  }
+
+  return statusTexts.get(response.status) ?? 'unknown';
+}
+
+export function statusAllowsBody(status: number) {
+  return (
+    status !== 204 &&
+    status !== 205 &&
+    status !== 304 &&
+    (status < 100 || status >= 200)
+  );
+}
+
+function hasResponseBody(response: Response) {
+  return !!response.body && statusAllowsBody(response.status);
+}
+
+function shouldChunkBody(
+  headers: Headers,
+  hasBody: boolean,
+  knownLength?: number
+) {
+  return (
+    hasBody &&
+    knownLength === undefined &&
+    !hasHeader(headers, 'content-length') &&
+    (!hasHeader(headers, 'transfer-encoding') ||
+      headerIncludes(headers, 'transfer-encoding', 'chunked'))
+  );
+}
+
+function chunk(chunk: Uint8Array) {
+  const head = encode(`${chunk.length.toString(16)}\r\n`);
+  const tail = encode('\r\n');
+  const result = new Uint8Array(head.length + chunk.length + tail.length);
+  result.set(head);
+  result.set(chunk, head.length);
+  result.set(tail, head.length + chunk.length);
+  return result;
+}
+
+async function pipeBody(
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  body: ReadableStream<Uint8Array> | null,
+  chunked: boolean
+) {
+  if (!body) {
+    controller.close();
+    return;
+  }
+
+  const reader = body.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      if (value.length === 0) {
+        continue;
+      }
+
+      controller.enqueue(chunked ? chunk(value) : value);
+    }
+
+    if (chunked) {
+      controller.enqueue(encode('0\r\n\r\n'));
+    }
+    controller.close();
+  } catch (error) {
+    controller.error(error);
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export function requestTarget(url: URL) {
+  return `${url.pathname || '/'}${url.search}`;
+}
+
+export function serializeHttpRequest(
+  request: Request,
+  body: SerializableHttpBody = request.body
+) {
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const url = new URL(request.url);
+      const stream = bodyStream(body);
+      const length = bodyLength(body);
+      const headers = requestHeaders(request, !!stream, length);
+
+      const lines = [`${request.method} ${requestTarget(url)} HTTP/1.1`];
+      appendHeaderLines(lines, headers);
+
+      controller.enqueue(encode(`${lines.join('\r\n')}\r\n\r\n`));
+      await pipeBody(
+        controller,
+        stream,
+        shouldChunkBody(new Headers(request.headers), !!stream, length)
+      );
+    },
+  });
+}
+
+export function serializeHttpResponse(response: Response) {
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const hasBody = hasResponseBody(response);
+      const headers = responseHeaders(response, hasBody);
+
+      const lines = [`HTTP/1.1 ${response.status} ${statusText(response)}`];
+      appendHeaderLines(lines, headers);
+
+      controller.enqueue(encode(`${lines.join('\r\n')}\r\n\r\n`));
+      await pipeBody(
+        controller,
+        hasBody ? response.body : null,
+        shouldChunkBody(new Headers(response.headers), hasBody)
+      );
+    },
+  });
+}

--- a/packages/http/src/serve.test.ts
+++ b/packages/http/src/serve.test.ts
@@ -1,0 +1,306 @@
+import { createStack } from 'tcpip';
+import { describe, expect, test } from 'vitest';
+import { createHttp } from './index.js';
+
+async function readHttpResponseText(readable: ReadableStream<Uint8Array>) {
+  const reader = readable.getReader();
+  let buffer = new Uint8Array();
+
+  while (true) {
+    let result: ReadableStreamReadResult<Uint8Array>;
+    try {
+      result = await reader.read();
+    } catch (error) {
+      if (buffer.length > 0) {
+        break;
+      }
+      throw error;
+    }
+
+    const { done, value } = result;
+    if (done) {
+      break;
+    }
+    buffer = concat(buffer, value);
+
+    const headerEnd = findHeaderEnd(buffer);
+    if (headerEnd === -1) {
+      continue;
+    }
+
+    const head = new TextDecoder().decode(buffer.slice(0, headerEnd));
+    const bodyStart = headerEnd + 4;
+
+    if (isChunked(head)) {
+      const totalLength = findChunkedEnd(buffer, bodyStart);
+      if (totalLength !== -1) {
+        reader.releaseLock();
+        return new TextDecoder().decode(buffer.slice(0, totalLength));
+      }
+      continue;
+    }
+
+    const contentLength = contentLengthFromHead(head);
+    const totalLength = bodyStart + contentLength;
+
+    if (buffer.length >= totalLength) {
+      reader.releaseLock();
+      return new TextDecoder().decode(buffer.slice(0, totalLength));
+    }
+  }
+
+  reader.releaseLock();
+  return new TextDecoder().decode(buffer);
+}
+
+async function readToEof(readable: ReadableStream<Uint8Array>) {
+  const reader = readable.getReader();
+  let buffer = new Uint8Array();
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        return new TextDecoder().decode(buffer);
+      }
+      buffer = concat(buffer, value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function concat(a: Uint8Array, b: Uint8Array) {
+  const result = new Uint8Array(a.length + b.length);
+  result.set(a);
+  result.set(b, a.length);
+  return result;
+}
+
+function findHeaderEnd(buffer: Uint8Array) {
+  for (let i = 0; i <= buffer.length - 4; i++) {
+    if (
+      buffer[i] === 13 &&
+      buffer[i + 1] === 10 &&
+      buffer[i + 2] === 13 &&
+      buffer[i + 3] === 10
+    ) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function findLineEnd(buffer: Uint8Array, offset: number) {
+  for (let i = offset; i <= buffer.length - 2; i++) {
+    if (buffer[i] === 13 && buffer[i + 1] === 10) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function findChunkedEnd(buffer: Uint8Array, bodyStart: number) {
+  let offset = bodyStart;
+
+  while (offset < buffer.length) {
+    const lineEnd = findLineEnd(buffer, offset);
+    if (lineEnd === -1) {
+      return -1;
+    }
+
+    const sizeLine = new TextDecoder().decode(buffer.slice(offset, lineEnd));
+    const size = Number.parseInt(sizeLine, 16);
+    if (Number.isNaN(size)) {
+      return -1;
+    }
+
+    if (size === 0) {
+      const messageEnd = lineEnd + 4;
+      return buffer.length >= messageEnd ? messageEnd : -1;
+    }
+
+    offset = lineEnd + 2 + size + 2;
+    if (buffer.length < offset) {
+      return -1;
+    }
+  }
+
+  return -1;
+}
+
+function isChunked(head: string) {
+  for (const line of head.split('\r\n').slice(1)) {
+    const index = line.indexOf(':');
+    const name = line.slice(0, index).toLowerCase();
+    const value = line
+      .slice(index + 1)
+      .trim()
+      .toLowerCase();
+    if (name === 'transfer-encoding' && value.includes('chunked')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function contentLengthFromHead(head: string) {
+  for (const line of head.split('\r\n').slice(1)) {
+    const index = line.indexOf(':');
+    const name = line.slice(0, index).toLowerCase();
+    const value = line.slice(index + 1).trim();
+    if (name === 'content-length') {
+      return Number(value);
+    }
+  }
+  return 0;
+}
+
+describe('serve', () => {
+  test('handler-only overload listens on the default HTTP port', async () => {
+    const stack = await createStack();
+    const { serve } = await createHttp(stack);
+
+    await serve(async (request) => {
+      expect(new URL(request.url).pathname).toBe('/default');
+      return new Response('ok');
+    });
+
+    const connection = await stack.connectTcp({
+      host: '127.0.0.1',
+      port: 80,
+    });
+
+    const writer = connection.writable.getWriter();
+    await writer.write(
+      new TextEncoder().encode(
+        'GET /default HTTP/1.1\r\nhost: example.test\r\nconnection: close\r\n\r\n'
+      )
+    );
+    writer.releaseLock();
+
+    const response = await readHttpResponseText(connection.readable);
+
+    expect(response).toBe(
+      'HTTP/1.1 200 OK\r\ncontent-type: text/plain;charset=UTF-8\r\nconnection: close\r\ntransfer-encoding: chunked\r\n\r\n2\r\nok\r\n0\r\n\r\n'
+    );
+  });
+
+  test('responds to a raw TCP HTTP request', async () => {
+    const stack = await createStack();
+    const { serve } = await createHttp(stack);
+
+    await serve({ host: '127.0.0.1', port: 8082 }, async (request) => {
+      expect(request.method).toBe('GET');
+      expect(new URL(request.url).pathname).toBe('/hello');
+      return new Response('world', {
+        headers: {
+          'content-type': 'text/plain',
+        },
+      });
+    });
+
+    const connection = await stack.connectTcp({
+      host: '127.0.0.1',
+      port: 8082,
+    });
+
+    const writer = connection.writable.getWriter();
+    await writer.write(
+      new TextEncoder().encode(
+        'GET /hello HTTP/1.1\r\nhost: 127.0.0.1:8082\r\nconnection: close\r\n\r\n'
+      )
+    );
+    writer.releaseLock();
+
+    const response = await readHttpResponseText(connection.readable);
+
+    expect(response).toBe(
+      'HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\nconnection: close\r\ntransfer-encoding: chunked\r\n\r\n5\r\nworld\r\n0\r\n\r\n'
+    );
+  });
+
+  test('closes the TCP readable after sending a response', async () => {
+    const stack = await createStack();
+    const { serve } = await createHttp(stack);
+
+    await serve({ host: '127.0.0.1', port: 8086 }, async () => {
+      return new Response('closed');
+    });
+
+    const connection = await stack.connectTcp({
+      host: '127.0.0.1',
+      port: 8086,
+    });
+
+    const writer = connection.writable.getWriter();
+    await writer.write(
+      new TextEncoder().encode(
+        'GET /closed HTTP/1.1\r\nhost: 127.0.0.1:8086\r\nconnection: close\r\n\r\n'
+      )
+    );
+    writer.releaseLock();
+
+    await expect(readToEof(connection.readable)).resolves.toBe(
+      'HTTP/1.1 200 OK\r\ncontent-type: text/plain;charset=UTF-8\r\nconnection: close\r\ntransfer-encoding: chunked\r\n\r\n6\r\nclosed\r\n0\r\n\r\n'
+    );
+  });
+
+  test('options-object overload accepts an inline handler', async () => {
+    const stack = await createStack();
+    const { serve } = await createHttp(stack);
+
+    await serve({
+      host: '127.0.0.1',
+      port: 8085,
+      handler: async () => new Response('inline'),
+    });
+
+    const connection = await stack.connectTcp({
+      host: '127.0.0.1',
+      port: 8085,
+    });
+
+    const writer = connection.writable.getWriter();
+    await writer.write(
+      new TextEncoder().encode(
+        'GET / HTTP/1.1\r\nhost: 127.0.0.1:8085\r\nconnection: close\r\n\r\n'
+      )
+    );
+    writer.releaseLock();
+
+    const response = await readHttpResponseText(connection.readable);
+
+    expect(response).toBe(
+      'HTTP/1.1 200 OK\r\ncontent-type: text/plain;charset=UTF-8\r\nconnection: close\r\ntransfer-encoding: chunked\r\n\r\n6\r\ninline\r\n0\r\n\r\n'
+    );
+  });
+
+  test('streams request body to handler', async () => {
+    const stack = await createStack();
+    const { serve } = await createHttp(stack);
+
+    await serve({ host: '127.0.0.1', port: 8083 }, async (request) => {
+      return new Response(await request.text());
+    });
+
+    const connection = await stack.connectTcp({
+      host: '127.0.0.1',
+      port: 8083,
+    });
+
+    const writer = connection.writable.getWriter();
+    await writer.write(
+      new TextEncoder().encode(
+        'POST /echo HTTP/1.1\r\nhost: 127.0.0.1:8083\r\ncontent-length: 7\r\nconnection: close\r\n\r\npayload'
+      )
+    );
+    writer.releaseLock();
+
+    const response = await readHttpResponseText(connection.readable);
+
+    expect(response).toBe(
+      'HTTP/1.1 200 OK\r\ncontent-type: text/plain;charset=UTF-8\r\nconnection: close\r\ntransfer-encoding: chunked\r\n\r\n7\r\npayload\r\n0\r\n\r\n'
+    );
+  });
+});

--- a/packages/http/src/serve.ts
+++ b/packages/http/src/serve.ts
@@ -1,0 +1,142 @@
+import type { NetworkStack, TcpConnection } from 'tcpip/types';
+import { HttpParser } from './parser.js';
+import { serializeHttpResponse } from './serialize.js';
+import type {
+  HttpParserRuntime,
+  HttpRequestHandler,
+  HttpServer,
+  ServeOptions,
+} from './types.js';
+
+function requestUrl(path: string, headers: Headers) {
+  const host = headers.get('host') ?? 'localhost';
+  return `http://${host}${path}`;
+}
+
+const supportsStreamingRequestBodies = detectStreamingRequestBodies();
+
+function detectStreamingRequestBodies() {
+  try {
+    const body = new ReadableStream<Uint8Array>();
+    const request = new Request('http://localhost/', {
+      method: 'POST',
+      body,
+      duplex: 'half',
+    } as RequestInit & { duplex: 'half' });
+    return request.body === body;
+  } catch {
+    return false;
+  }
+}
+
+async function handleConnection(
+  connection: TcpConnection,
+  parserRuntime: HttpParserRuntime,
+  handler: HttpRequestHandler
+) {
+  const parser = new HttpParser(parserRuntime, 'request');
+  const messagePromise = parser.nextMessage();
+  const reader = connection.readable.getReader();
+
+  const readPromise = (async () => {
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        parser.write(value);
+        if (parser.closed) {
+          break;
+        }
+      }
+      if (!parser.closed) {
+        parser.finish();
+      }
+    } catch (error) {
+      if (
+        !(error instanceof Error && error.message === 'tcp connection closed')
+      ) {
+        throw error;
+      }
+      parser.finish();
+    }
+  })().finally(() => {
+    reader.releaseLock();
+  });
+  readPromise.catch((error) => {
+    console.error('error reading http request:', error);
+  });
+
+  const message = await messagePromise;
+
+  if (message.type !== 'request') {
+    throw new Error('expected http request');
+  }
+
+  const requestInit: RequestInit & { duplex?: 'half' } = {
+    method: message.method,
+    headers: message.headers,
+  };
+
+  if (message.method !== 'GET' && message.method !== 'HEAD') {
+    if (supportsStreamingRequestBodies) {
+      requestInit.body = message.body;
+      requestInit.duplex = 'half';
+    } else {
+      requestInit.body = await new Response(message.body).arrayBuffer();
+    }
+  }
+
+  const request = new Request(
+    requestUrl(message.url, message.headers),
+    requestInit
+  );
+
+  const response = await handler(request);
+  await serializeHttpResponse(response).pipeTo(connection.writable, {
+    preventClose: true,
+  });
+
+  const writer = connection.writable.getWriter();
+  try {
+    await writer.close();
+  } finally {
+    writer.releaseLock();
+  }
+}
+
+export async function serveHttp(
+  stack: NetworkStack,
+  parserRuntime: HttpParserRuntime,
+  options: ServeOptions,
+  handler: HttpRequestHandler
+): Promise<HttpServer> {
+  const listener = await stack.listenTcp(options);
+  let closed = false;
+
+  const loop = (async () => {
+    for await (const connection of listener) {
+      if (closed) {
+        await connection.close();
+        continue;
+      }
+
+      handleConnection(connection, parserRuntime, handler).catch((error) => {
+        console.error('error handling http connection:', error);
+      });
+    }
+  })();
+
+  loop.catch((error) => {
+    if (!closed) {
+      console.error('error in http server loop:', error);
+    }
+  });
+
+  return {
+    async close() {
+      closed = true;
+    },
+  };
+}

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -1,0 +1,103 @@
+import type { NetworkStack } from 'tcpip/types';
+
+export type HttpFetch = typeof globalThis.fetch;
+
+export type ServeOptions = {
+  /**
+   * The local host to bind to.
+   *
+   * If not provided, the server binds to all available interfaces.
+   */
+  host?: string;
+  port: number;
+};
+
+export type ServeHandlerOptions = Partial<ServeOptions> & {
+  handler: HttpRequestHandler;
+};
+
+export type HttpServer = {
+  close(): Promise<void>;
+};
+
+export type HttpRequestHandler = (
+  request: Request
+) => Response | Promise<Response>;
+
+export type CreateHttpOptions = {
+  /**
+   * Parser runtime override used by tests.
+   */
+  parser?: HttpParserRuntime;
+};
+
+export type HttpApi = {
+  fetch: HttpFetch;
+  serve(handler: HttpRequestHandler): Promise<HttpServer>;
+  serve(
+    options: ServeOptions,
+    handler: HttpRequestHandler
+  ): Promise<HttpServer>;
+  serve(options: ServeHandlerOptions): Promise<HttpServer>;
+};
+
+export type CreateHttp = (
+  stack: NetworkStack,
+  options?: CreateHttpOptions
+) => Promise<HttpApi>;
+
+export type HttpParserType = 'request' | 'response';
+
+export type HttpHeadersEvent = {
+  parserType: HttpParserType;
+  method?: string;
+  url?: string;
+  statusCode?: number;
+  statusText?: string;
+  httpMajor: number;
+  httpMinor: number;
+  headers: [string, string][];
+  shouldKeepAlive: boolean;
+  upgrade: boolean;
+};
+
+export type ParsedHttpRequest = {
+  type: 'request';
+  method: string;
+  url: string;
+  httpMajor: number;
+  httpMinor: number;
+  headers: Headers;
+  body: ReadableStream<Uint8Array>;
+  shouldKeepAlive: boolean;
+  upgrade: boolean;
+};
+
+export type ParsedHttpResponse = {
+  type: 'response';
+  statusCode: number;
+  statusText: string;
+  httpMajor: number;
+  httpMinor: number;
+  headers: Headers;
+  body: ReadableStream<Uint8Array>;
+  shouldKeepAlive: boolean;
+  upgrade: boolean;
+};
+
+export type ParsedHttpMessage = ParsedHttpRequest | ParsedHttpResponse;
+
+export type HttpParserRuntime = {
+  ready?: () => Promise<void>;
+  createParser(type: HttpParserType, parser: HttpParserCallbacks): number;
+  executeParser(handle: number, chunk: Uint8Array): void;
+  finishParser(handle: number): void;
+  freeParser(handle: number): void;
+};
+
+export type HttpParserCallbacks = {
+  headers(event: HttpHeadersEvent): void;
+  body(chunk: Uint8Array): void;
+  complete(): void;
+  error(error: Error): void;
+};

--- a/packages/http/src/wasm/bindings.test.ts
+++ b/packages/http/src/wasm/bindings.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, test } from 'vitest';
+import { HttpParser } from '../parser.js';
+import { LlhttpBindings } from './bindings.js';
+
+const encoder = new TextEncoder();
+
+async function readText(readable: ReadableStream<Uint8Array>) {
+  const chunks: Uint8Array[] = [];
+  const reader = readable.getReader();
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    chunks.push(value);
+  }
+
+  const length = chunks.reduce((total, chunk) => total + chunk.length, 0);
+  const result = new Uint8Array(length);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return new TextDecoder().decode(result);
+}
+
+describe('LlhttpBindings', () => {
+  test('parses a response with streamed body bytes', async () => {
+    const runtime = new LlhttpBindings();
+    await runtime.ready();
+
+    const parser = new HttpParser(runtime, 'response');
+    const messagePromise = parser.nextMessage();
+
+    parser.write(
+      encoder.encode(
+        'HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\ncontent-length: 5\r\nconnection: close\r\n\r\nhello'
+      )
+    );
+
+    const message = await messagePromise;
+    if (message.type !== 'response') {
+      throw new Error('expected response');
+    }
+    expect(message.statusCode).toBe(200);
+    expect(message.headers.get('content-type')).toBe('text/plain');
+    await expect(readText(message.body)).resolves.toBe('hello');
+
+    parser.close();
+  });
+
+  test('parses a request with streamed body bytes', async () => {
+    const runtime = new LlhttpBindings();
+    await runtime.ready();
+
+    const parser = new HttpParser(runtime, 'request');
+    const messagePromise = parser.nextMessage();
+
+    parser.write(
+      encoder.encode(
+        'POST /submit HTTP/1.1\r\nhost: example.com\r\ncontent-length: 7\r\nconnection: close\r\n\r\npayload'
+      )
+    );
+
+    const message = await messagePromise;
+    if (message.type !== 'request') {
+      throw new Error('expected request');
+    }
+    expect(message.method).toBe('POST');
+    expect(message.url).toBe('/submit');
+    expect(message.headers.get('host')).toBe('example.com');
+    await expect(readText(message.body)).resolves.toBe('payload');
+
+    parser.close();
+  });
+
+  test('parses header fragments split across writes', async () => {
+    const runtime = new LlhttpBindings();
+    await runtime.ready();
+
+    const parser = new HttpParser(runtime, 'request');
+    const messagePromise = parser.nextMessage();
+
+    parser.write(encoder.encode('GET /split HTTP/1.1\r\ncontent-'));
+    parser.write(encoder.encode('type: text/'));
+    parser.write(encoder.encode('plain\r\nhost: example.com\r\n\r\n'));
+
+    const message = await messagePromise;
+    if (message.type !== 'request') {
+      throw new Error('expected request');
+    }
+    expect(message.url).toBe('/split');
+    expect(message.headers.get('content-type')).toBe('text/plain');
+    expect(message.headers.get('host')).toBe('example.com');
+    await expect(readText(message.body)).resolves.toBe('');
+
+    parser.close();
+  });
+
+  test('parses chunked bodies as streamed decoded bytes', async () => {
+    const runtime = new LlhttpBindings();
+    await runtime.ready();
+
+    const parser = new HttpParser(runtime, 'request');
+    const messagePromise = parser.nextMessage();
+
+    parser.write(
+      encoder.encode(
+        'POST /chunked HTTP/1.1\r\nhost: example.com\r\ntransfer-encoding: chunked\r\n\r\n'
+      )
+    );
+    parser.write(encoder.encode('5\r\nhello\r\n'));
+    parser.write(encoder.encode('6\r\n world\r\n0\r\n\r\n'));
+
+    const message = await messagePromise;
+    if (message.type !== 'request') {
+      throw new Error('expected request');
+    }
+    await expect(readText(message.body)).resolves.toBe('hello world');
+
+    parser.close();
+  });
+
+  test('routes callbacks to independent parser handles', async () => {
+    const runtime = new LlhttpBindings();
+    await runtime.ready();
+
+    const requestParser = new HttpParser(runtime, 'request');
+    const responseParser = new HttpParser(runtime, 'response');
+    const requestPromise = requestParser.nextMessage();
+    const responsePromise = responseParser.nextMessage();
+
+    requestParser.write(
+      encoder.encode(
+        'POST /a HTTP/1.1\r\nhost: example.com\r\ncontent-length: 3\r\n\r\none'
+      )
+    );
+    responseParser.write(
+      encoder.encode('HTTP/1.1 201 Created\r\ncontent-length: 3\r\n\r\ntwo')
+    );
+
+    const request = await requestPromise;
+    const response = await responsePromise;
+    if (request.type !== 'request' || response.type !== 'response') {
+      throw new Error('expected request and response');
+    }
+
+    expect(request.url).toBe('/a');
+    await expect(readText(request.body)).resolves.toBe('one');
+    expect(response.statusCode).toBe(201);
+    await expect(readText(response.body)).resolves.toBe('two');
+
+    requestParser.close();
+    responseParser.close();
+  });
+
+  test('keeps interleaved streamed bodies isolated across parser handles', async () => {
+    const runtime = new LlhttpBindings();
+    await runtime.ready();
+
+    const firstParser = new HttpParser(runtime, 'request');
+    const secondParser = new HttpParser(runtime, 'request');
+    const firstPromise = firstParser.nextMessage();
+    const secondPromise = secondParser.nextMessage();
+
+    firstParser.write(
+      encoder.encode(
+        'POST /first HTTP/1.1\r\nhost: example.com\r\ntransfer-encoding: chunked\r\n\r\n'
+      )
+    );
+    secondParser.write(
+      encoder.encode(
+        'POST /second HTTP/1.1\r\nhost: example.com\r\ntransfer-encoding: chunked\r\n\r\n'
+      )
+    );
+
+    const first = await firstPromise;
+    const second = await secondPromise;
+    if (first.type !== 'request' || second.type !== 'request') {
+      throw new Error('expected requests');
+    }
+
+    const firstText = readText(first.body);
+    const secondText = readText(second.body);
+
+    firstParser.write(encoder.encode('3\r\none\r\n'));
+    secondParser.write(encoder.encode('3\r\ntwo\r\n'));
+    firstParser.write(encoder.encode('5\r\nthree\r\n'));
+    secondParser.write(encoder.encode('4\r\nfour\r\n'));
+    firstParser.write(encoder.encode('0\r\n\r\n'));
+    secondParser.write(encoder.encode('0\r\n\r\n'));
+
+    expect(first.url).toBe('/first');
+    expect(second.url).toBe('/second');
+    await expect(firstText).resolves.toBe('onethree');
+    await expect(secondText).resolves.toBe('twofour');
+
+    firstParser.close();
+    secondParser.close();
+  });
+
+  test('reports parse errors through pending message promises', async () => {
+    const runtime = new LlhttpBindings();
+    await runtime.ready();
+
+    const parser = new HttpParser(runtime, 'request');
+    const messagePromise = parser.nextMessage();
+
+    expect(() => parser.write(encoder.encode('not http\r\n\r\n'))).toThrow(
+      'http parse failed with code'
+    );
+    await expect(messagePromise).rejects.toThrow('http parse failed with code');
+
+    parser.close();
+  });
+
+  test('throws when writing after close', async () => {
+    const runtime = new LlhttpBindings();
+    await runtime.ready();
+
+    const parser = new HttpParser(runtime, 'request');
+    parser.close();
+
+    expect(() =>
+      parser.write(encoder.encode('GET / HTTP/1.1\r\n\r\n'))
+    ).toThrow('http parser is closed');
+  });
+});

--- a/packages/http/src/wasm/bindings.ts
+++ b/packages/http/src/wasm/bindings.ts
@@ -1,0 +1,220 @@
+import { ConsoleStdout, File, OpenFile, WASI } from '@bjorn3/browser_wasi_shim';
+import type {
+  HttpHeadersEvent,
+  HttpParserCallbacks,
+  HttpParserRuntime,
+  HttpParserType,
+} from '../types.js';
+import { fetchFile } from './fetch-file.js';
+import type { LlhttpExports, LlhttpImports, Pointer } from './types.js';
+
+const HTTP_REQUEST = 0;
+const HTTP_RESPONSE = 1;
+
+const decoder = new TextDecoder();
+
+export class LlhttpBindings implements HttpParserRuntime {
+  #exports?: LlhttpExports;
+  #parsers = new Map<Pointer, HttpParserCallbacks>();
+
+  imports: LlhttpImports = {
+    parsed_http_headers: (
+      handle,
+      parserType,
+      methodPtr,
+      methodLength,
+      urlPtr,
+      urlLength,
+      statusCode,
+      statusPtr,
+      statusLength,
+      httpMajor,
+      httpMinor,
+      headersPtr,
+      headersLength,
+      shouldKeepAlive,
+      upgrade
+    ) => {
+      const callbacks = this.#getCallbacks(handle);
+      callbacks.headers({
+        parserType: parserType === HTTP_REQUEST ? 'request' : 'response',
+        method: this.#readString(methodPtr, methodLength) || undefined,
+        url: this.#readString(urlPtr, urlLength) || undefined,
+        statusCode: parserType === HTTP_RESPONSE ? statusCode : undefined,
+        statusText: this.#readString(statusPtr, statusLength) || undefined,
+        httpMajor,
+        httpMinor,
+        headers: this.#readHeaders(headersPtr, headersLength),
+        shouldKeepAlive: shouldKeepAlive === 1,
+        upgrade: upgrade === 1,
+      } satisfies HttpHeadersEvent);
+    },
+    parsed_http_body: (handle, chunkPtr, chunkLength) => {
+      const callbacks = this.#getCallbacks(handle);
+      callbacks.body(this.copyFromMemory(chunkPtr, chunkLength));
+    },
+    completed_http_message: (handle) => {
+      this.#getCallbacks(handle).complete();
+    },
+    failed_http_parse: (handle, code, reasonPtr) => {
+      this.#getCallbacks(handle).error(
+        new Error(
+          `http parse failed with code ${code}: ${this.#readCString(reasonPtr)}`
+        )
+      );
+    },
+  };
+
+  get exports() {
+    if (!this.#exports) {
+      throw new Error('llhttp exports were not registered');
+    }
+    return this.#exports;
+  }
+
+  async ready() {
+    const wasi = new WASI(
+      [],
+      [],
+      [
+        new OpenFile(new File([])),
+        ConsoleStdout.lineBuffered((msg) =>
+          console.log(`[WASI stdout] ${msg}`)
+        ),
+        ConsoleStdout.lineBuffered((msg) =>
+          console.warn(`[WASI stderr] ${msg}`)
+        ),
+      ]
+    );
+    const { instance } = await WebAssembly.instantiateStreaming(
+      this.#source(),
+      {
+        wasi_snapshot_preview1: wasi.wasiImport,
+        env: this.imports,
+      }
+    );
+    this.#exports = (instance as unknown as { exports: LlhttpExports }).exports;
+    wasi.initialize(instance as unknown as { exports: LlhttpExports });
+  }
+
+  async #source() {
+    // Source tests run from src/wasm; published builds run from dist. Try both
+    // relative paths back to the package-root wasm asset.
+    const urls = [
+      new URL('../../http_parser.wasm', import.meta.url),
+      new URL('../http_parser.wasm', import.meta.url),
+    ];
+
+    let lastError: unknown;
+    for (const url of urls) {
+      try {
+        const response = await fetchFile(url, 'application/wasm');
+        if (response.ok) {
+          return response;
+        }
+        lastError = new Error(`failed to fetch ${url}: ${response.status}`);
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    throw lastError;
+  }
+
+  createParser(type: HttpParserType, callbacks: HttpParserCallbacks) {
+    const handle = this.exports.create_http_parser(
+      type === 'request' ? HTTP_REQUEST : HTTP_RESPONSE
+    );
+    this.#parsers.set(handle, callbacks);
+    return handle;
+  }
+
+  executeParser(handle: number, chunk: Uint8Array) {
+    const chunkPtr = this.copyToMemory(chunk);
+    try {
+      const result = this.exports.execute_http_parser(
+        handle,
+        chunkPtr,
+        chunk.length
+      );
+      if (result !== 0) {
+        throw new Error(`http parse failed with code ${result}`);
+      }
+    } finally {
+      this.exports.free(chunkPtr);
+    }
+  }
+
+  finishParser(handle: number) {
+    const result = this.exports.finish_http_parser(handle);
+    if (result !== 0) {
+      throw new Error(`http parser finish failed with code ${result}`);
+    }
+  }
+
+  freeParser(handle: number) {
+    this.exports.free_http_parser(handle);
+    this.#parsers.delete(handle);
+  }
+
+  copyToMemory(data: Uint8Array) {
+    const ptr = this.exports.malloc(data.length);
+    this.viewFromMemory(ptr, data.length).set(data);
+    return ptr;
+  }
+
+  copyFromMemory(ptr: number, length: number) {
+    const buffer = this.exports.memory.buffer.slice(ptr, ptr + length);
+    return new Uint8Array(buffer);
+  }
+
+  viewFromMemory(ptr: number, length: number) {
+    return new Uint8Array(this.exports.memory.buffer, ptr, length);
+  }
+
+  #getCallbacks(handle: Pointer) {
+    const callbacks = this.#parsers.get(handle);
+    if (!callbacks) {
+      throw new Error(`unknown http parser handle: ${handle}`);
+    }
+    return callbacks;
+  }
+
+  #readString(ptr: number, length: number) {
+    if (ptr === 0 || length === 0) {
+      return '';
+    }
+    return decoder.decode(this.copyFromMemory(ptr, length));
+  }
+
+  #readCString(ptr: number) {
+    if (ptr === 0) {
+      return '';
+    }
+
+    const memory = new Uint8Array(this.exports.memory.buffer);
+    let end = ptr;
+    while (memory[end] !== 0) {
+      end++;
+    }
+    return decoder.decode(memory.slice(ptr, end));
+  }
+
+  #readHeaders(ptr: number, length: number) {
+    const text = this.#readString(ptr, length);
+    if (!text) {
+      return [];
+    }
+
+    return text
+      .split('\0')
+      .filter(Boolean)
+      .map((line) => {
+        const index = line.indexOf(':');
+        return [line.slice(0, index), line.slice(index + 1)] satisfies [
+          string,
+          string,
+        ];
+      });
+  }
+}

--- a/packages/http/src/wasm/fetch-file.ts
+++ b/packages/http/src/wasm/fetch-file.ts
@@ -1,0 +1,20 @@
+const IN_NODE =
+  typeof process === 'object' &&
+  typeof process.versions === 'object' &&
+  typeof process.versions.node === 'string';
+
+export async function fetchFile(input: string | URL, type: string) {
+  if (IN_NODE) {
+    return fetchFileNode(input, type);
+  }
+  return fetch(input);
+}
+
+async function fetchFileNode(input: string | URL, type: string) {
+  const fs = await import('node:fs');
+  await fs.promises.access(input);
+  const { Readable } = await import('node:stream');
+  const nodeStream = fs.createReadStream(input);
+  const stream = Readable.toWeb(nodeStream) as ReadableStream<Uint8Array>;
+  return new Response(stream, { headers: { 'Content-Type': type } });
+}

--- a/packages/http/src/wasm/types.ts
+++ b/packages/http/src/wasm/types.ts
@@ -1,0 +1,47 @@
+export type Pointer = number;
+
+export type LlhttpImports = {
+  parsed_http_headers(
+    handle: Pointer,
+    parserType: number,
+    methodPtr: number,
+    methodLength: number,
+    urlPtr: number,
+    urlLength: number,
+    statusCode: number,
+    statusPtr: number,
+    statusLength: number,
+    httpMajor: number,
+    httpMinor: number,
+    headersPtr: number,
+    headersLength: number,
+    shouldKeepAlive: number,
+    upgrade: number
+  ): void;
+  parsed_http_body(
+    handle: Pointer,
+    chunkPtr: number,
+    chunkLength: number
+  ): void;
+  completed_http_message(handle: Pointer): void;
+  failed_http_parse(handle: Pointer, code: number, reasonPtr: number): void;
+};
+
+export type LlhttpExports = {
+  memory: WebAssembly.Memory;
+  _initialize(): unknown;
+  malloc(size: number): number;
+  free(ptr: number): void;
+  create_http_parser(type: number): Pointer;
+  execute_http_parser(
+    handle: Pointer,
+    chunkPtr: number,
+    chunkLength: number
+  ): number;
+  finish_http_parser(handle: Pointer): number;
+  free_http_parser(handle: Pointer): void;
+};
+
+export type LlhttpWasmInstance = {
+  exports: LlhttpExports;
+};

--- a/packages/http/tsconfig.json
+++ b/packages/http/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@total-typescript/tsconfig/tsc/dom/library",
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "lib": ["es2022", "dom", "dom.iterable", "esnext.disposable"],
+    "paths": {
+      "tcpip": ["../tcpip/src/index.js"],
+      "tcpip/types": ["../tcpip/src/types.js"],
+      "@tcpip/http": ["./src/index.js"]
+    }
+  }
+}

--- a/packages/http/tsconfig.json
+++ b/packages/http/tsconfig.json
@@ -6,6 +6,8 @@
     "paths": {
       "tcpip": ["../tcpip/src/index.js"],
       "tcpip/types": ["../tcpip/src/types.js"],
+      "@tcpip/dns": ["../dns/src/index.js"],
+      "@tcpip/wire": ["../wire/src/index.js"],
       "@tcpip/http": ["./src/index.js"]
     }
   }

--- a/packages/http/tsup.config.ts
+++ b/packages/http/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    outDir: 'dist',
+    sourcemap: true,
+    dts: true,
+    minify: true,
+    splitting: true,
+  },
+]);

--- a/packages/http/vitest.workspace.ts
+++ b/packages/http/vitest.workspace.ts
@@ -1,0 +1,34 @@
+import { defineWorkspace } from 'vitest/config';
+
+export default defineWorkspace([
+  {
+    esbuild: {
+      target: 'es2022',
+    },
+    test: {
+      name: 'node',
+      environment: 'node',
+      include: ['src/**/*.{test,spec}.ts'],
+    },
+  },
+  {
+    esbuild: {
+      target: 'es2022',
+    },
+    test: {
+      name: 'browser',
+      include: ['src/**/*.{test,spec}.ts'],
+      browser: {
+        enabled: true,
+        provider: 'playwright',
+        instances: [
+          { browser: 'chromium' },
+          { browser: 'firefox' },
+          { browser: 'webkit' },
+        ],
+        headless: true,
+        screenshotFailures: false,
+      },
+    },
+  },
+]);

--- a/packages/http/wasm/http_parser.c
+++ b/packages/http/wasm/http_parser.c
@@ -1,0 +1,228 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "llhttp.h"
+
+#define EXPORT(name) __attribute__((export_name(name)))
+
+#define HTTP_REQUEST_TYPE 0
+#define HTTP_RESPONSE_TYPE 1
+
+extern void parsed_http_headers(
+    void *handle,
+    int parser_type,
+    const char *method,
+    int method_length,
+    const char *url,
+    int url_length,
+    int status_code,
+    const char *status,
+    int status_length,
+    int http_major,
+    int http_minor,
+    const char *headers,
+    int headers_length,
+    int should_keep_alive,
+    int upgrade);
+
+extern void parsed_http_body(void *handle, const char *chunk, int chunk_length);
+extern void completed_http_message(void *handle);
+extern void failed_http_parse(void *handle, int code, const char *reason);
+
+typedef struct {
+  llhttp_t parser;
+  llhttp_settings_t settings;
+  int parser_type;
+  char *method;
+  size_t method_length;
+  char *url;
+  size_t url_length;
+  char *status;
+  size_t status_length;
+  char *header_field;
+  size_t header_field_length;
+  char *header_value;
+  size_t header_value_length;
+  char *headers;
+  size_t headers_length;
+} http_parser_wrapper_t;
+
+static int append_bytes(char **target, size_t *target_length, const char *at, size_t length) {
+  char *next = realloc(*target, *target_length + length);
+  if (next == NULL) {
+    return -1;
+  }
+
+  memcpy(next + *target_length, at, length);
+  *target = next;
+  *target_length += length;
+  return 0;
+}
+
+static void clear_buffer(char **target, size_t *target_length) {
+  free(*target);
+  *target = NULL;
+  *target_length = 0;
+}
+
+static int append_header(http_parser_wrapper_t *wrapper) {
+  if (wrapper->header_field_length == 0) {
+    return 0;
+  }
+
+  size_t added_length = wrapper->header_field_length + 1 + wrapper->header_value_length + 1;
+  char *next = realloc(wrapper->headers, wrapper->headers_length + added_length);
+  if (next == NULL) {
+    return -1;
+  }
+
+  wrapper->headers = next;
+  memcpy(wrapper->headers + wrapper->headers_length, wrapper->header_field, wrapper->header_field_length);
+  wrapper->headers_length += wrapper->header_field_length;
+  wrapper->headers[wrapper->headers_length++] = ':';
+  memcpy(wrapper->headers + wrapper->headers_length, wrapper->header_value, wrapper->header_value_length);
+  wrapper->headers_length += wrapper->header_value_length;
+  wrapper->headers[wrapper->headers_length++] = '\0';
+
+  clear_buffer(&wrapper->header_field, &wrapper->header_field_length);
+  clear_buffer(&wrapper->header_value, &wrapper->header_value_length);
+  return 0;
+}
+
+static int on_message_begin(llhttp_t *parser) {
+  http_parser_wrapper_t *wrapper = parser->data;
+  clear_buffer(&wrapper->method, &wrapper->method_length);
+  clear_buffer(&wrapper->url, &wrapper->url_length);
+  clear_buffer(&wrapper->status, &wrapper->status_length);
+  clear_buffer(&wrapper->header_field, &wrapper->header_field_length);
+  clear_buffer(&wrapper->header_value, &wrapper->header_value_length);
+  clear_buffer(&wrapper->headers, &wrapper->headers_length);
+  return 0;
+}
+
+static int on_method(llhttp_t *parser, const char *at, size_t length) {
+  http_parser_wrapper_t *wrapper = parser->data;
+  return append_bytes(&wrapper->method, &wrapper->method_length, at, length);
+}
+
+static int on_url(llhttp_t *parser, const char *at, size_t length) {
+  http_parser_wrapper_t *wrapper = parser->data;
+  return append_bytes(&wrapper->url, &wrapper->url_length, at, length);
+}
+
+static int on_status(llhttp_t *parser, const char *at, size_t length) {
+  http_parser_wrapper_t *wrapper = parser->data;
+  return append_bytes(&wrapper->status, &wrapper->status_length, at, length);
+}
+
+static int on_header_field(llhttp_t *parser, const char *at, size_t length) {
+  http_parser_wrapper_t *wrapper = parser->data;
+  if (wrapper->header_value_length > 0 && append_header(wrapper) != 0) {
+    return -1;
+  }
+  return append_bytes(&wrapper->header_field, &wrapper->header_field_length, at, length);
+}
+
+static int on_header_value(llhttp_t *parser, const char *at, size_t length) {
+  http_parser_wrapper_t *wrapper = parser->data;
+  return append_bytes(&wrapper->header_value, &wrapper->header_value_length, at, length);
+}
+
+static int on_headers_complete(llhttp_t *parser) {
+  http_parser_wrapper_t *wrapper = parser->data;
+  if (append_header(wrapper) != 0) {
+    return -1;
+  }
+
+  parsed_http_headers(
+      wrapper,
+      wrapper->parser_type,
+      wrapper->method,
+      (int)wrapper->method_length,
+      wrapper->url,
+      (int)wrapper->url_length,
+      llhttp_get_status_code(parser),
+      wrapper->status,
+      (int)wrapper->status_length,
+      llhttp_get_http_major(parser),
+      llhttp_get_http_minor(parser),
+      wrapper->headers,
+      (int)wrapper->headers_length,
+      llhttp_should_keep_alive(parser),
+      llhttp_get_upgrade(parser));
+
+  return 0;
+}
+
+static int on_body(llhttp_t *parser, const char *at, size_t length) {
+  http_parser_wrapper_t *wrapper = parser->data;
+  parsed_http_body(wrapper, at, (int)length);
+  return 0;
+}
+
+static int on_message_complete(llhttp_t *parser) {
+  http_parser_wrapper_t *wrapper = parser->data;
+  completed_http_message(wrapper);
+  return 0;
+}
+
+EXPORT("create_http_parser")
+http_parser_wrapper_t *create_http_parser(int type) {
+  http_parser_wrapper_t *wrapper = calloc(1, sizeof(http_parser_wrapper_t));
+  if (wrapper == NULL) {
+    return NULL;
+  }
+
+  wrapper->parser_type = type;
+  llhttp_settings_init(&wrapper->settings);
+  wrapper->settings.on_message_begin = on_message_begin;
+  wrapper->settings.on_method = on_method;
+  wrapper->settings.on_url = on_url;
+  wrapper->settings.on_status = on_status;
+  wrapper->settings.on_header_field = on_header_field;
+  wrapper->settings.on_header_value = on_header_value;
+  wrapper->settings.on_headers_complete = on_headers_complete;
+  wrapper->settings.on_body = on_body;
+  wrapper->settings.on_message_complete = on_message_complete;
+
+  llhttp_init(
+      &wrapper->parser,
+      type == HTTP_REQUEST_TYPE ? HTTP_REQUEST : HTTP_RESPONSE,
+      &wrapper->settings);
+  wrapper->parser.data = wrapper;
+  return wrapper;
+}
+
+EXPORT("execute_http_parser")
+int execute_http_parser(http_parser_wrapper_t *wrapper, const char *data, size_t length) {
+  llhttp_errno_t err = llhttp_execute(&wrapper->parser, data, length);
+  if (err != HPE_OK) {
+    failed_http_parse(wrapper, err, llhttp_get_error_reason(&wrapper->parser));
+  }
+  return err;
+}
+
+EXPORT("finish_http_parser")
+int finish_http_parser(http_parser_wrapper_t *wrapper) {
+  llhttp_errno_t err = llhttp_finish(&wrapper->parser);
+  if (err != HPE_OK) {
+    failed_http_parse(wrapper, err, llhttp_get_error_reason(&wrapper->parser));
+  }
+  return err;
+}
+
+EXPORT("free_http_parser")
+void free_http_parser(http_parser_wrapper_t *wrapper) {
+  if (wrapper == NULL) {
+    return;
+  }
+
+  clear_buffer(&wrapper->method, &wrapper->method_length);
+  clear_buffer(&wrapper->url, &wrapper->url_length);
+  clear_buffer(&wrapper->status, &wrapper->status_length);
+  clear_buffer(&wrapper->header_field, &wrapper->header_field_length);
+  clear_buffer(&wrapper->header_value, &wrapper->header_value_length);
+  clear_buffer(&wrapper->headers, &wrapper->headers_length);
+  free(wrapper);
+}

--- a/packages/http/wasm/include/README.md
+++ b/packages/http/wasm/include/README.md
@@ -1,0 +1,12 @@
+# llhttp sources
+
+The Makefile downloads llhttp into `packages/http/llhttp`, matching the Makefile-managed lwIP checkout used by `packages/tcpip`.
+
+The build uses the specified release branch which contains generated C sources and headers:
+
+- `llhttp/include/llhttp.h`
+- `llhttp/src/llhttp.c`
+- `llhttp/src/api.c`
+- `llhttp/src/http.c`
+
+The wrapper exports a small tcpip-style handle API to TypeScript.

--- a/packages/tcpip/src/bindings/tcp.ts
+++ b/packages/tcpip/src/bindings/tcp.ts
@@ -25,6 +25,7 @@ type TcpConnectionOuterHooks = {
   send(data: Uint8Array): Promise<void>;
   updateReceiveBuffer(length: number): void;
   close(): Promise<void>;
+  closeWrite(): Promise<void>;
 };
 
 type TcpConnectionInnerHooks = {
@@ -68,6 +69,7 @@ export type TcpExports = {
   create_tcp_listener(host: Pointer | null, port: number): TcpListenerHandle;
   create_tcp_connection(host: Pointer, port: number): TcpConnectionHandle;
   close_tcp_connection(handle: TcpConnectionHandle): number;
+  shutdown_tcp_connection_write(handle: TcpConnectionHandle): number;
   send_tcp_chunk(
     handle: TcpConnectionHandle,
     chunk: number,
@@ -80,6 +82,7 @@ export class TcpBindings extends Bindings<TcpImports, TcpExports> {
   #tcpListeners = new Map<TcpListenerHandle, TcpListener>();
   #tcpConnections = new EventMap<TcpConnectionHandle, TcpConnection>();
   #tcpAcks = new Map<TcpConnectionHandle, (length: number) => void>();
+  #tcpCloseAcks = new Map<TcpConnectionHandle, () => void>();
   #dnsClient: DnsClient;
 
   async #resolveHost(host: string) {
@@ -94,6 +97,42 @@ export class TcpBindings extends Bindings<TcpImports, TcpExports> {
   constructor(dnsClient: DnsClient) {
     super();
     this.#dnsClient = dnsClient;
+  }
+
+  async #closeConnection(handle: TcpConnectionHandle) {
+    while (true) {
+      const result = this.exports.close_tcp_connection(handle);
+
+      if (result === LwipError.ERR_OK) {
+        return;
+      }
+
+      if (result !== LwipError.ERR_MEM) {
+        throw new Error(`failed to close tcp connection: ${result}`);
+      }
+
+      await new Promise<void>((resolve) => {
+        this.#tcpCloseAcks.set(handle, resolve);
+      });
+    }
+  }
+
+  async #closeConnectionWrite(handle: TcpConnectionHandle) {
+    while (true) {
+      const result = this.exports.shutdown_tcp_connection_write(handle);
+
+      if (result === LwipError.ERR_OK) {
+        return;
+      }
+
+      if (result !== LwipError.ERR_MEM) {
+        throw new Error(`failed to shutdown tcp write side: ${result}`);
+      }
+
+      await new Promise<void>((resolve) => {
+        this.#tcpCloseAcks.set(handle, resolve);
+      });
+    }
   }
 
   imports = {
@@ -142,11 +181,10 @@ export class TcpBindings extends Bindings<TcpImports, TcpExports> {
           this.exports.update_tcp_receive_buffer(connectionHandle, length);
         },
         close: async () => {
-          const result = this.exports.close_tcp_connection(connectionHandle);
-
-          if (result !== LwipError.ERR_OK) {
-            throw new Error(`failed to close tcp connection: ${result}`);
-          }
+          await this.#closeConnection(connectionHandle);
+        },
+        closeWrite: async () => {
+          await this.#closeConnectionWrite(connectionHandle);
         },
       });
 
@@ -189,7 +227,10 @@ export class TcpBindings extends Bindings<TcpImports, TcpExports> {
           this.exports.update_tcp_receive_buffer(handle, length);
         },
         close: async () => {
-          this.exports.close_tcp_connection(handle);
+          await this.#closeConnection(handle);
+        },
+        closeWrite: async () => {
+          await this.#closeConnectionWrite(handle);
         },
       });
 
@@ -227,6 +268,10 @@ export class TcpBindings extends Bindings<TcpImports, TcpExports> {
       const notifyAck = this.#tcpAcks.get(handle);
       this.#tcpAcks.delete(handle);
       notifyAck?.(length);
+
+      const notifyCloseAck = this.#tcpCloseAcks.get(handle);
+      this.#tcpCloseAcks.delete(handle);
+      notifyCloseAck?.();
     },
   };
 
@@ -294,6 +339,8 @@ export class VirtualTcpConnection
   #receiveBuffer: Uint8Array[] = [];
   #readableController?: ReadableStreamDefaultController<Uint8Array>;
   #writableController?: WritableStreamDefaultController;
+  #remoteClosed = false;
+  #readableClosed = false;
 
   readable: ReadableStream<Uint8Array>;
   writable: WritableStream<Uint8Array>;
@@ -307,7 +354,9 @@ export class VirtualTcpConnection
         this.#enqueueBuffer();
       },
       close: async () => {
-        this.close();
+        await nextMicrotask();
+        this.#remoteClosed = true;
+        this.#enqueueBuffer();
       },
     });
 
@@ -334,6 +383,9 @@ export class VirtualTcpConnection
         write: async (chunk) => {
           await tcpConnectionHooks.getOuter(this).send(chunk);
         },
+        close: async () => {
+          await tcpConnectionHooks.getOuter(this).closeWrite();
+        },
       },
       {
         // Send buffer is managed by the TCP stack
@@ -342,7 +394,35 @@ export class VirtualTcpConnection
     );
   }
 
+  #closeReadable() {
+    if (this.#readableClosed) {
+      return;
+    }
+
+    this.#readableClosed = true;
+    try {
+      this.#readableController?.close();
+    } catch {}
+  }
+
+  #errorReadable(error: Error) {
+    if (this.#readableClosed) {
+      return;
+    }
+
+    this.#readableClosed = true;
+    try {
+      this.#readableController?.error(error);
+    } catch {}
+  }
+
   #enqueueBuffer() {
+    if (this.#remoteClosed && this.#receiveBuffer.length === 0) {
+      this.#closeReadable();
+      this.#writableController?.error(new Error('tcp connection closed'));
+      return;
+    }
+
     if (!(this.#readableController?.desiredSize! > 0)) {
       return;
     }
@@ -371,11 +451,16 @@ export class VirtualTcpConnection
     if (bytesEnqueued > 0) {
       tcpConnectionHooks.getOuter(this).updateReceiveBuffer(bytesEnqueued);
     }
+
+    if (this.#remoteClosed && this.#receiveBuffer.length === 0) {
+      this.#closeReadable();
+      this.#writableController?.error(new Error('tcp connection closed'));
+    }
   }
 
   async close() {
     await tcpConnectionHooks.getOuter(this).close();
-    this.#readableController?.error(new Error('tcp connection closed'));
+    this.#errorReadable(new Error('tcp connection closed'));
     this.#writableController?.error(new Error('tcp connection closed'));
   }
 

--- a/packages/tcpip/src/bindings/tcp.ts
+++ b/packages/tcpip/src/bindings/tcp.ts
@@ -388,8 +388,9 @@ export class VirtualTcpConnection
         },
       },
       {
-        // Send buffer is managed by the TCP stack
-        highWaterMark: 0,
+        // Send buffer capacity is managed by the TCP stack. Allow one queued
+        // write so standard stream utilities like pipeTo() can start flowing.
+        highWaterMark: 1,
       }
     );
   }

--- a/packages/tcpip/src/stack.test.ts
+++ b/packages/tcpip/src/stack.test.ts
@@ -634,6 +634,262 @@ describe('tcp', () => {
     await outbound.close();
   });
 
+  test('delivers queued TCP data before peer close is observed', async () => {
+    const stack = await createStack();
+
+    const listener = await stack.listenTcp({
+      host: '127.0.0.1',
+      port: 8080,
+    });
+
+    const [outbound, inbound] = await Promise.all([
+      stack.connectTcp({
+        host: '127.0.0.1',
+        port: 8080,
+      }),
+      nextValue(listener),
+    ]);
+
+    const inboundWriter = inbound.writable.getWriter();
+    const outboundReader = outbound.readable.getReader();
+    const data = new TextEncoder().encode('queued before close');
+
+    await inboundWriter.write(data);
+    inboundWriter.releaseLock();
+    await inbound.close();
+
+    await expect(outboundReader.read()).resolves.toMatchObject({
+      done: false,
+      value: data,
+    });
+    await expect(outboundReader.read()).resolves.toMatchObject({ done: true });
+  });
+
+  test('closing a TCP writable delivers queued data before peer EOF', async () => {
+    const stack = await createStack();
+
+    const listener = await stack.listenTcp({
+      host: '127.0.0.1',
+      port: 8080,
+    });
+
+    const [outbound, inbound] = await Promise.all([
+      stack.connectTcp({
+        host: '127.0.0.1',
+        port: 8080,
+      }),
+      nextValue(listener),
+    ]);
+
+    const inboundWriter = inbound.writable.getWriter();
+    const outboundReader = outbound.readable.getReader();
+    const data = new TextEncoder().encode('queued before writable close');
+
+    await inboundWriter.write(data);
+    await inboundWriter.close();
+
+    await expect(outboundReader.read()).resolves.toMatchObject({
+      done: false,
+      value: data,
+    });
+    await expect(outboundReader.read()).resolves.toMatchObject({ done: true });
+  });
+
+  test('closing a TCP writable after multiple writes delivers queued data before peer EOF', async () => {
+    const stack = await createStack();
+
+    const listener = await stack.listenTcp({
+      host: '127.0.0.1',
+      port: 8080,
+    });
+
+    const [outbound, inbound] = await Promise.all([
+      stack.connectTcp({
+        host: '127.0.0.1',
+        port: 8080,
+      }),
+      nextValue(listener),
+    ]);
+
+    const inboundWriter = inbound.writable.getWriter();
+    const outboundReader = outbound.readable.getReader();
+    const first = new TextEncoder().encode('first');
+    const second = new TextEncoder().encode('second');
+
+    await inboundWriter.write(first);
+    await inboundWriter.write(second);
+    await inboundWriter.close();
+
+    await expect(outboundReader.read()).resolves.toMatchObject({
+      done: false,
+      value: first,
+    });
+    await expect(outboundReader.read()).resolves.toMatchObject({
+      done: false,
+      value: second,
+    });
+    await expect(outboundReader.read()).resolves.toMatchObject({ done: true });
+  });
+
+  test('TCP peer EOF is observable after releasing a reader that consumed queued data', async () => {
+    const stack = await createStack();
+
+    const listener = await stack.listenTcp({
+      host: '127.0.0.1',
+      port: 8080,
+    });
+
+    const [outbound, inbound] = await Promise.all([
+      stack.connectTcp({
+        host: '127.0.0.1',
+        port: 8080,
+      }),
+      nextValue(listener),
+    ]);
+
+    const inboundWriter = inbound.writable.getWriter();
+    const firstReader = outbound.readable.getReader();
+    const data = new TextEncoder().encode('complete message');
+
+    await inboundWriter.write(data);
+    await inboundWriter.close();
+
+    await expect(firstReader.read()).resolves.toMatchObject({
+      done: false,
+      value: data,
+    });
+    firstReader.releaseLock();
+
+    const secondReader = outbound.readable.getReader();
+    await expect(secondReader.read()).resolves.toMatchObject({ done: true });
+  });
+
+  test('server can read a request then gracefully close its response stream', async () => {
+    const stack = await createStack();
+
+    const listener = await stack.listenTcp({
+      host: '127.0.0.1',
+      port: 8080,
+    });
+
+    const [client, server] = await Promise.all([
+      stack.connectTcp({
+        host: '127.0.0.1',
+        port: 8080,
+      }),
+      nextValue(listener),
+    ]);
+
+    const clientWriter = client.writable.getWriter();
+    const serverReader = server.readable.getReader();
+    const serverWriter = server.writable.getWriter();
+    const clientReader = client.readable.getReader();
+    const request = new TextEncoder().encode('request');
+    const response = new TextEncoder().encode('response');
+
+    await clientWriter.write(request);
+    await expect(serverReader.read()).resolves.toMatchObject({
+      done: false,
+      value: request,
+    });
+    serverReader.releaseLock();
+
+    await serverWriter.write(response);
+    await serverWriter.close();
+
+    await expect(clientReader.read()).resolves.toMatchObject({
+      done: false,
+      value: response,
+    });
+    await expect(clientReader.read()).resolves.toMatchObject({ done: true });
+  });
+
+  test('server can gracefully close its response stream while a request read is pending', async () => {
+    const stack = await createStack();
+
+    const listener = await stack.listenTcp({
+      host: '127.0.0.1',
+      port: 8080,
+    });
+
+    const [client, server] = await Promise.all([
+      stack.connectTcp({
+        host: '127.0.0.1',
+        port: 8080,
+      }),
+      nextValue(listener),
+    ]);
+
+    const clientWriter = client.writable.getWriter();
+    const serverReader = server.readable.getReader();
+    const serverWriter = server.writable.getWriter();
+    const clientReader = client.readable.getReader();
+    const request = new TextEncoder().encode('request');
+    const response = new TextEncoder().encode('response');
+
+    await clientWriter.write(request);
+    await expect(serverReader.read()).resolves.toMatchObject({
+      done: false,
+      value: request,
+    });
+    serverReader.read().catch(() => {});
+
+    await serverWriter.write(response);
+    await serverWriter.close();
+
+    await expect(clientReader.read()).resolves.toMatchObject({
+      done: false,
+      value: response,
+    });
+    await expect(clientReader.read()).resolves.toMatchObject({ done: true });
+  });
+
+  test('server can gracefully close after a multi-chunk response while a request read is pending', async () => {
+    const stack = await createStack();
+
+    const listener = await stack.listenTcp({
+      host: '127.0.0.1',
+      port: 8080,
+    });
+
+    const [client, server] = await Promise.all([
+      stack.connectTcp({
+        host: '127.0.0.1',
+        port: 8080,
+      }),
+      nextValue(listener),
+    ]);
+
+    const clientWriter = client.writable.getWriter();
+    const serverReader = server.readable.getReader();
+    const serverWriter = server.writable.getWriter();
+    const clientReader = client.readable.getReader();
+    const request = new TextEncoder().encode('request');
+    const responseHead = new Uint8Array(92).fill(1);
+    const responseTail = new Uint8Array(15).fill(2);
+
+    await clientWriter.write(request);
+    await expect(serverReader.read()).resolves.toMatchObject({
+      done: false,
+      value: request,
+    });
+    serverReader.read().catch(() => {});
+
+    await serverWriter.write(responseHead);
+    await serverWriter.write(responseTail);
+    await serverWriter.close();
+
+    await expect(clientReader.read()).resolves.toMatchObject({
+      done: false,
+      value: responseHead,
+    });
+    await expect(clientReader.read()).resolves.toMatchObject({
+      done: false,
+      value: responseTail,
+    });
+    await expect(clientReader.read()).resolves.toMatchObject({ done: true });
+  });
+
   test('can close a TCP connection when reader/writer are locked', async () => {
     const stack = await createStack();
 

--- a/packages/tcpip/src/stack.test.ts
+++ b/packages/tcpip/src/stack.test.ts
@@ -695,6 +695,39 @@ describe('tcp', () => {
     await expect(outboundReader.read()).resolves.toMatchObject({ done: true });
   });
 
+  test('can pipe a readable stream to a TCP writable', async () => {
+    const stack = await createStack();
+
+    const listener = await stack.listenTcp({
+      host: '127.0.0.1',
+      port: 8080,
+    });
+
+    const [outbound, inbound] = await Promise.all([
+      stack.connectTcp({
+        host: '127.0.0.1',
+        port: 8080,
+      }),
+      nextValue(listener),
+    ]);
+
+    const data = new TextEncoder().encode('piped to tcp');
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(data);
+        controller.close();
+      },
+    });
+    const inboundReader = inbound.readable.getReader();
+
+    await source.pipeTo(outbound.writable, { preventClose: true });
+
+    await expect(inboundReader.read()).resolves.toMatchObject({
+      done: false,
+      value: data,
+    });
+  });
+
   test('closing a TCP writable after multiple writes delivers queued data before peer EOF', async () => {
     const stack = await createStack();
 

--- a/packages/tcpip/wasm/tcp.c
+++ b/packages/tcpip/wasm/tcp.c
@@ -45,6 +45,11 @@ err_t close_tcp_connection(struct tcp_pcb *conn) {
   return tcp_close(conn);
 }
 
+EXPORT("shutdown_tcp_connection_write")
+err_t shutdown_tcp_connection_write(struct tcp_pcb *conn) {
+  return tcp_shutdown(conn, 0, 1);
+}
+
 // Callback for when data is received
 err_t recv_tcp_callback(void *arg, struct tcp_pcb *conn, struct pbuf *p, err_t err) {
   // TODO: review this logic (should we half-close?)

--- a/packages/v86/package.json
+++ b/packages/v86/package.json
@@ -16,6 +16,7 @@
     "build": "tsup --clean",
     "clean": "rm -rf dist",
     "test": "vitest",
+    "vm:shell": "tsx test/vm-shell.ts",
     "prepublishOnly": "pnpm run build"
   },
   "files": ["dist/**/*"],
@@ -28,11 +29,13 @@
   },
   "devDependencies": {
     "@tcpip/dhcp": "workspace:*",
+    "@tcpip/http": "workspace:*",
     "@tcpip/wire": "workspace:*",
     "@total-typescript/tsconfig": "catalog:",
     "@types/node": "catalog:",
     "tsup": "catalog:",
     "tcpip": "workspace:*",
+    "tsx": "catalog:",
     "typescript": "catalog:",
     "v86": "^0.5.44",
     "vitest": "catalog:"

--- a/packages/v86/src/network-adapter.test.ts
+++ b/packages/v86/src/network-adapter.test.ts
@@ -1,4 +1,5 @@
 import { createDhcp } from '@tcpip/dhcp';
+import { createHttp } from '@tcpip/http';
 import { type TcpSegment, parseEthernetFrame } from '@tcpip/wire';
 import { connectStreams, createStack } from 'tcpip';
 import { describe, expect, it } from 'vitest';
@@ -102,6 +103,30 @@ describe('network adapter', () => {
     expect(textDecoder.decode(message)).toBe('Hello');
 
     await connection.close();
+    await emulator.destroy();
+  });
+
+  it('should serve HTTP responses to a VM', async () => {
+    const networkStack = await createStack();
+    const tapInterface = await networkStack.createTapInterface({
+      ip: '192.168.1.1/24',
+    });
+
+    const { emulator, net, executeCommand } = await createVm({
+      ip: '192.168.1.2/24',
+    });
+
+    connectStreams(tapInterface, net);
+
+    const { serve } = await createHttp(networkStack);
+    await serve(() => {
+      return new Response('hello from tcpip.js');
+    });
+
+    const response = await executeCommand('wget -qO- http://192.168.1.1/hello');
+
+    expect(response).toBe('hello from tcpip.js');
+
     await emulator.destroy();
   });
 

--- a/packages/v86/test/vm-shell.ts
+++ b/packages/v86/test/vm-shell.ts
@@ -1,0 +1,62 @@
+/// <reference types="node" />
+
+import { stdin, stdout } from 'node:process';
+import { createInterface } from 'node:readline/promises';
+import { createVm } from './util.js';
+
+function parseArgs(args: string[]) {
+  const ipIndex = args.indexOf('--ip');
+  const ip = ipIndex === -1 ? undefined : args[ipIndex + 1];
+  const command = args
+    .filter((_, index) => index !== ipIndex && index !== ipIndex + 1)
+    .join(' ')
+    .trim();
+
+  return { ip, command };
+}
+
+async function main() {
+  const { ip, command } = parseArgs(process.argv.slice(2));
+  const { emulator, executeCommand } = await createVm({ ip });
+
+  try {
+    if (command) {
+      const output = await executeCommand(command);
+      if (output) {
+        console.log(output);
+      }
+      return;
+    }
+
+    const readline = createInterface({
+      input: stdin,
+      output: stdout,
+      prompt: 'v86$ ',
+    });
+
+    readline.prompt();
+    for await (const line of readline) {
+      const nextCommand = line.trim();
+      if (nextCommand === 'exit') {
+        break;
+      }
+
+      if (nextCommand) {
+        const output = await executeCommand(nextCommand);
+        if (output) {
+          console.log(output);
+        }
+      }
+      readline.prompt();
+    }
+
+    readline.close();
+  } finally {
+    await emulator.destroy();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/v86/tsconfig.json
+++ b/packages/v86/tsconfig.json
@@ -8,6 +8,7 @@
       "tcpip/types": ["../tcpip/src/types.js"],
       "@tcpip/dhcp": ["../dhcp/src/index.js"],
       "@tcpip/dns": ["../dns/src/index.js"],
+      "@tcpip/http": ["../http/src/index.js"],
       "@tcpip/wire": ["../wire/src/index.js"]
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ catalogs:
       specifier: ^8.3.5
       version: 8.5.1
     tsx:
-      specifier: ^4.19.2
+      specifier: ^4.21.0
       version: 4.21.0
     typescript:
       specifier: ^5.8.3
@@ -86,6 +86,36 @@ importers:
         specifier: 'catalog:'
         version: 3.2.4(@types/node@22.19.17)(@vitest/browser@3.2.4)(tsx@4.21.0)
 
+  packages/http:
+    devDependencies:
+      '@bjorn3/browser_wasi_shim':
+        specifier: ^0.3.0
+        version: 0.3.0
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.59.1
+      '@total-typescript/tsconfig':
+        specifier: 'catalog:'
+        version: 1.0.4
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.17
+      '@vitest/browser':
+        specifier: 'catalog:'
+        version: 3.2.4(playwright@1.59.1)(vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0))(vitest@3.2.4)
+      tcpip:
+        specifier: workspace:*
+        version: link:../tcpip
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/node@22.19.17)(@vitest/browser@3.2.4)(tsx@4.21.0)
+
   packages/tcpip:
     dependencies:
       '@bjorn3/browser_wasi_shim':
@@ -128,6 +158,9 @@ importers:
       '@tcpip/dhcp':
         specifier: workspace:*
         version: link:../dhcp
+      '@tcpip/http':
+        specifier: workspace:*
+        version: link:../http
       '@tcpip/wire':
         specifier: workspace:*
         version: link:../wire
@@ -143,6 +176,9 @@ importers:
       tsup:
         specifier: 'catalog:'
         version: 8.5.1(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.21.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,6 @@
 packages:
   - 'packages/*'
 
-ignoredBuiltDependencies:
-  - '@biomejs/biome'
-  - esbuild
-
 catalog:
   '@biomejs/biome': ^1.9.0
   '@playwright/test': ^1.52.0
@@ -12,6 +8,10 @@ catalog:
   '@types/node': ^22.15.19
   '@vitest/browser': ^3.1.2
   tsup: ^8.3.5
-  tsx: ^4.19.2
+  tsx: ^4.21.0
   typescript: ^5.8.3
   vitest: ^3.1.4
+
+ignoredBuiltDependencies:
+  - '@biomejs/biome'
+  - esbuild

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,9 @@
     "packages/wire": {
       "component": "@tcpip/wire"
     },
+    "packages/http": {
+      "component": "@tcpip/http"
+    },
     "packages/dns": {
       "component": "@tcpip/dns"
     },


### PR DESCRIPTION
Adds `@tcpip/http` package. Builds on top of `tcpip` TCP streams, and exposes a web standard fetch-compatible API:

```ts
import { createStack } from 'tcpip';
import { createHttp } from '@tcpip/http';

const stack = await createStack();
const { fetch, serve } = await createHttp(stack);

await serve(async (request) => {
  return new Response('hello from tcpip.js');
});

const response = await fetch('http://127.0.0.1/hello');
console.log(await response.text());
// hello from tcpip.js
```

HTTP implementations are mostly parser-heavy - it's a lot of work to parse the many HTTP edge cases to ensure spec compliance. For this reason, we lean on [llhttp](https://github.com/nodejs/llhttp), the real HTTP C parser for Node.js. We compile it to a small wasm module and write bindings to interface between C and JS. HTTP serialization is relatively straightforward so is done in pure JS.