### PR TITLE
fix(tcp): register accepted connections before yielding

### DIFF
--- a/packages/tcpip/src/bindings/tcp.ts
+++ b/packages/tcpip/src/bindings/tcp.ts
@@ -80,7 +80,8 @@ export type TcpExports = {
 
 export class TcpBindings extends Bindings<TcpImports, TcpExports> {
   #tcpListeners = new Map<TcpListenerHandle, TcpListener>();
-  #tcpConnections = new EventMap<TcpConnectionHandle, TcpConnection>();
+  #tcpConnections = new Map<TcpConnectionHandle, TcpConnection>();
+  #tcpConnectEvents = new EventMap<TcpConnectionHandle, TcpConnection>();
   #tcpAcks = new Map<TcpConnectionHandle, (length: number) => void>();
   #tcpCloseAcks = new Map<TcpConnectionHandle, () => void>();
   #dnsClient: DnsClient;
@@ -147,9 +148,6 @@ export class TcpBindings extends Bindings<TcpImports, TcpExports> {
         return;
       }
 
-      // Wait for synchronous lwIP operations to complete to prevent reentrancy issues
-      await nextMicrotask();
-
       const connection = new VirtualTcpConnection();
 
       tcpConnectionHooks.setOuter(connection, {
@@ -190,12 +188,13 @@ export class TcpBindings extends Bindings<TcpImports, TcpExports> {
 
       this.#tcpConnections.set(connectionHandle, connection);
 
+      // Wait for synchronous lwIP operations to complete to prevent reentrancy issues.
+      // The handle is registered first so early peer data is not dropped.
+      await nextMicrotask();
+
       tcpListenerHooks.getInner(listener).accept(connection);
     },
     connected_tcp_connection: async (handle: TcpConnectionHandle) => {
-      // Wait for synchronous lwIP operations to complete to prevent reentrancy issues
-      await nextMicrotask();
-
       const connection = new VirtualTcpConnection();
 
       tcpConnectionHooks.setOuter(connection, {
@@ -235,6 +234,12 @@ export class TcpBindings extends Bindings<TcpImports, TcpExports> {
       });
 
       this.#tcpConnections.set(handle, connection);
+
+      // Wait for synchronous lwIP operations to complete to prevent reentrancy issues.
+      // The handle is registered first so early peer data is not dropped.
+      await nextMicrotask();
+
+      this.#tcpConnectEvents.set(handle, connection);
     },
     closed_tcp_connection: async (handle: TcpConnectionHandle) => {
       const connection = this.#tcpConnections.get(handle);
@@ -296,7 +301,7 @@ export class TcpBindings extends Bindings<TcpImports, TcpExports> {
 
     const handle = this.exports.create_tcp_connection(hostPtr, options.port);
 
-    const tcpConnection = await this.#tcpConnections.wait(handle);
+    const tcpConnection = await this.#tcpConnectEvents.wait(handle);
 
     if (!tcpConnection) {
       throw new Error('tcp failed to connect');

--- a/packages/tcpip/src/stack.test.ts
+++ b/packages/tcpip/src/stack.test.ts
@@ -11,6 +11,7 @@ import {
   MAX_WINDOW_SIZE,
   READABLE_HIGH_WATER_MARK,
   SEND_BUFFER_SIZE,
+  TcpBindings,
 } from './bindings/tcp.js';
 import { createStack } from './index.js';
 
@@ -587,6 +588,69 @@ describe('bridge interface', () => {
 });
 
 describe('tcp', () => {
+  test('routes TCP data that arrives before accepted connection is yielded', async () => {
+    const tcpBindings = new TcpBindings({
+      lookup: vi.fn(),
+    } as unknown as ConstructorParameters<typeof TcpBindings>[0]);
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const data = new TextEncoder().encode('early data');
+    const dataPtr = 16;
+    const listenerHandle = 1 as Parameters<
+      typeof tcpBindings.imports.accept_tcp_connection
+    >[0];
+    const connectionHandle = 2 as Parameters<
+      typeof tcpBindings.imports.accept_tcp_connection
+    >[1];
+    new Uint8Array(memory.buffer).set(data, dataPtr);
+
+    tcpBindings.register({
+      memory,
+      create_tcp_listener: vi.fn(() => 1),
+      create_tcp_connection: vi.fn(),
+      close_tcp_connection: vi.fn(() => 0),
+      shutdown_tcp_connection_write: vi.fn(() => 0),
+      send_tcp_chunk: vi.fn(() => 0),
+      update_tcp_receive_buffer: vi.fn(),
+      get_interface_mac_address: vi.fn(),
+      get_interface_ip4_address: vi.fn(),
+      get_interface_ip4_netmask: vi.fn(),
+      _initialize: vi.fn(),
+      malloc: vi.fn(),
+      free: vi.fn(),
+    } as Parameters<typeof tcpBindings.register>[0]);
+
+    const listener = await tcpBindings.listen({ port: 8080 });
+    const connectionPromise = nextValue(listener);
+    const acceptPromise = tcpBindings.imports.accept_tcp_connection(
+      listenerHandle,
+      connectionHandle
+    );
+    const receivePromise = tcpBindings.imports.receive_tcp_chunk(
+      connectionHandle,
+      dataPtr,
+      data.length
+    );
+
+    const connection = await connectionPromise;
+    await Promise.all([acceptPromise, receivePromise]);
+
+    const reader = connection.readable.getReader();
+    const received = await Promise.race([
+      reader.read(),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error('timed out waiting for TCP data')),
+          50
+        )
+      ),
+    ]);
+
+    expect(received).toMatchObject({
+      done: false,
+      value: data,
+    });
+  });
+
   test('can create a TCP server and client', async () => {
     const stack = await createStack();
 


### PR DESCRIPTION
Inbound TCP requests could occasionally hang because early TCP request data was dropped as `received chunk on unknown tcp connection` before the accepted connection reached JS userland. This registers the connection handle before the microtask boundary, so early peer data is routed correctly.