### PR TITLE
fix(http): resolve parser wasm from package root

### DIFF
--- a/packages/http/src/wasm-url.ts
+++ b/packages/http/src/wasm-url.ts
@@ -1,0 +1,4 @@
+export const httpParserWasmUrl = new URL(
+  '../http_parser.wasm',
+  import.meta.url
+);

--- a/packages/http/src/wasm/bindings.test.ts
+++ b/packages/http/src/wasm/bindings.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { HttpParser } from '../parser.js';
+import { httpParserWasmUrl } from '../wasm-url.js';
 import { LlhttpBindings } from './bindings.js';
 
 const encoder = new TextEncoder();
@@ -29,6 +30,14 @@ async function readText(readable: ReadableStream<Uint8Array>) {
 }
 
 describe('LlhttpBindings', () => {
+  test('uses the package wasm asset URL', () => {
+    expect(httpParserWasmUrl.pathname).toMatch(/\/http_parser\.wasm$/);
+    expect(httpParserWasmUrl.pathname).not.toContain('/src/');
+    expect(httpParserWasmUrl.pathname).not.toMatch(
+      /\/@tcpip\/http_parser\.wasm$/
+    );
+  });
+
   test('parses a response with streamed body bytes', async () => {
     const runtime = new LlhttpBindings();
     await runtime.ready();

--- a/packages/http/src/wasm/bindings.ts
+++ b/packages/http/src/wasm/bindings.ts
@@ -5,6 +5,7 @@ import type {
   HttpParserRuntime,
   HttpParserType,
 } from '../types.js';
+import { httpParserWasmUrl } from '../wasm-url.js';
 import { fetchFile } from './fetch-file.js';
 import type { LlhttpExports, LlhttpImports, Pointer } from './types.js';
 
@@ -98,27 +99,7 @@ export class LlhttpBindings implements HttpParserRuntime {
   }
 
   async #source() {
-    // Source tests run from src/wasm; published builds run from dist. Try both
-    // relative paths back to the package-root wasm asset.
-    const urls = [
-      new URL('../../http_parser.wasm', import.meta.url),
-      new URL('../http_parser.wasm', import.meta.url),
-    ];
-
-    let lastError: unknown;
-    for (const url of urls) {
-      try {
-        const response = await fetchFile(url, 'application/wasm');
-        if (response.ok) {
-          return response;
-        }
-        lastError = new Error(`failed to fetch ${url}: ${response.status}`);
-      } catch (error) {
-        lastError = error;
-      }
-    }
-
-    throw lastError;
+    return fetchFile(httpParserWasmUrl, 'application/wasm');
   }
 
   createParser(type: HttpParserType, callbacks: HttpParserCallbacks) {


### PR DESCRIPTION
Fixes `@tcpip/http` resolving `http_parser.wasm` from the wrong path in published builds.